### PR TITLE
Moved 'properties' up the GeoJSON class tree

### DIFF
--- a/src/main/java/org/geojson/Feature.java
+++ b/src/main/java/org/geojson/Feature.java
@@ -1,11 +1,7 @@
 package org.geojson;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class Feature extends GeoJsonObject {
 
-	private Map<String, Object> properties = new HashMap<>();
 	private GeoJsonObject geometry;
 	private String id;
 
@@ -15,23 +11,6 @@ public class Feature extends GeoJsonObject {
 
 	public void setGeometry(GeoJsonObject geometry) {
 		this.geometry = geometry;
-	}
-
-	public void setProperty(String key, Object value) {
-		properties.put(key, value);
-	}
-
-	@SuppressWarnings("unchecked")
-	public <T> T getProperty(String key) {
-		return (T)properties.get(key);
-	}
-
-	public Map<String, Object> getProperties() {
-		return properties;
-	}
-
-	public void setProperties(Map<String, Object> properties) {
-		this.properties = properties;
 	}
 
 	public String getId() {

--- a/src/main/java/org/geojson/GeoJsonObject.java
+++ b/src/main/java/org/geojson/GeoJsonObject.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @JsonTypeInfo(property = "type", use = Id.NAME)
 @JsonSubTypes({ @Type(Feature.class), @Type(Polygon.class), @Type(MultiPolygon.class), @Type(FeatureCollection.class),
 		@Type(Point.class), @Type(MultiPoint.class), @Type(MultiLineString.class), @Type(LineString.class) })
@@ -15,6 +18,9 @@ public abstract class GeoJsonObject {
 
 	private Crs crs;
 	private double[] bbox;
+
+  @JsonInclude(Include.NON_EMPTY)
+	private Map<String, Object> properties = new HashMap<>();
 
 	public Crs getCrs() {
 		return crs;
@@ -30,5 +36,22 @@ public abstract class GeoJsonObject {
 
 	public void setBbox(double[] bbox) {
 		this.bbox = bbox;
+	}
+	
+  public void setProperty(String key, Object value) {
+		properties.put(key, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> T getProperty(String key) {
+		return (T)properties.get(key);
+	}
+
+	public Map<String, Object> getProperties() {
+		return properties;
+	}
+
+	public void setProperties(Map<String, Object> properties) {
+		this.properties = properties;
 	}
 }


### PR DESCRIPTION
My reading of section 1 GeoJSON (http://geojson.org/geojson-spec.html#introduction) spec says that properties can be held by most any type of data.  Not having the properties prevented deserialization of US counties found in the world.geo.json collection (https://github.com/johan/world.geo.json).

This pull request moves the properties dictionary up to a higher point in the class tree.  It also adds an annotation to prevent serialization of the properties dictionary when there are none (thus, tests did not need to change).
