### PR TITLE
[feature/faster]: Replaced Double.toString() with custom serializer function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	
 	<groupId>de.grundid.opendatalab</groupId>
 	<artifactId>geojson-jackson</artifactId>
-	<version>1.2-SNAPSHOT</version>
+	<version>1.3</version>
 	<packaging>jar</packaging>
 
 

--- a/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
+++ b/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
@@ -15,10 +15,47 @@ public class LngLatAltSerializer extends JsonSerializer<LngLatAlt> {
 	public void serialize(LngLatAlt value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
 			JsonProcessingException {
 		jgen.writeStartArray();
-		jgen.writeNumber(value.getLongitude());
-		jgen.writeNumber(value.getLatitude());
-		if (value.hasAltitude())
-			jgen.writeNumber(value.getAltitude());
+		jgen.writeRaw(LngLatAltSerializer.format(value.getLongitude(), 9));
+		jgen.writeRaw(',');
+		jgen.writeRaw(LngLatAltSerializer.format(value.getLatitude(), 9));
+		if (value.hasAltitude()){
+			jgen.writeRaw(',');
+			jgen.writeRaw(LngLatAltSerializer.format(value.getAltitude(), 9));
+
+		}
 		jgen.writeEndArray();
 	}
+
+	public static final long POW10[] = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
+
+/**
+ * The following must convert double to String in a much more efficient way then Double.toString() 
+ * 
+ * @See http://stackoverflow.com/questions/10553710/fast-double-to-string-conversion-with-given-precision	
+ * @param val
+ * @param precision
+ * @return
+ */
+	 protected static String format(double val, int precision) {
+	     StringBuilder sb = new StringBuilder();
+	     if (val < 0) {
+	         sb.append('-');
+	         val = -val;
+	     }
+	     long exp = POW10[precision];
+	     long lval = (long)(val * exp + 0.5);
+	     sb.append(lval / exp).append('.');
+	     long fval = lval % exp;
+	     for (int p = precision - 1; p > 0 && fval < POW10[p] && fval>0; p--) {
+	         sb.append('0');
+	     }
+	     sb.append(fval);
+	     int i = sb.length()-1;
+	     while(sb.charAt(i)=='0' && sb.charAt(i-1)!='.')
+	     {
+	    	 sb.deleteCharAt(i);
+	    	 i--;
+	     }
+	     return sb.toString();
+	 }
 }


### PR DESCRIPTION
While profiling my project, pbf2geojson convertor I have realized that around 50% of the time is spent with method dtoa() (See http://cr.openjdk.java.net/~bpb/7192954_4396272_7039391/src/share/classes/sun/misc/FloatingDecimal.java-.html), which is used in Double.toString()
I have changed the LngLatAltSerializer to write doubles without invoking this Double.toString()

Thank you for your work!