### PR TITLE
Add toWKT() implementation

### DIFF
--- a/src/main/java/org/geojson/Geometry.java
+++ b/src/main/java/org/geojson/Geometry.java
@@ -56,4 +56,22 @@ public abstract class Geometry<T> extends GeoJsonObject {
 	public String toString() {
 		return "Geometry{" + "coordinates=" + coordinates + "} " + super.toString();
 	}
+
+    /**
+     * @param points List of points
+     * @return Return String with the following format : "lon lat, lon lat, ..."
+     */
+    protected String toWKT(List<LngLatAlt> points) {
+        String wkt = "";
+        boolean first = true;
+        for (LngLatAlt coords : points) {
+            if (first) {
+                first = false;
+            } else {
+                wkt += ",";
+            }
+            wkt += coords.getLongitude() + " " + coords.getLatitude();
+        }
+        return wkt;
+    }
 }

--- a/src/main/java/org/geojson/LineString.java
+++ b/src/main/java/org/geojson/LineString.java
@@ -1,5 +1,7 @@
 package org.geojson;
 
+import java.util.List;
+
 public class LineString extends MultiPoint {
 
 	public LineString() {
@@ -18,4 +20,11 @@ public class LineString extends MultiPoint {
 	public String toString() {
 		return "LineString{} " + super.toString();
 	}
+
+    public String toWKT() {
+        if (coordinates != null && coordinates.size() > 0) {
+            return "LINESTRING(" + toWKT(coordinates) + ")";
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/geojson/MultiLineString.java
+++ b/src/main/java/org/geojson/MultiLineString.java
@@ -20,4 +20,22 @@ public class MultiLineString extends Geometry<List<LngLatAlt>> {
 	public String toString() {
 		return "MultiLineString{} " + super.toString();
 	}
+
+    public String toWKT() {
+        if (coordinates != null && coordinates.size() > 0) {
+            String wkt = "MULTILINESTRING(";
+            boolean first = true;
+            for (List<LngLatAlt> line : coordinates) {
+                if (first) {
+                    first = false;
+                } else {
+                    wkt += ",";
+                }
+                wkt += "(" + toWKT(line) + ")";
+            }
+            wkt += ")";
+            return wkt;
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/geojson/MultiPoint.java
+++ b/src/main/java/org/geojson/MultiPoint.java
@@ -1,5 +1,7 @@
 package org.geojson;
 
+import java.util.List;
+
 public class MultiPoint extends Geometry<LngLatAlt> {
 
 	public MultiPoint() {
@@ -18,4 +20,11 @@ public class MultiPoint extends Geometry<LngLatAlt> {
 	public String toString() {
 		return "MultiPoint{} " + super.toString();
 	}
+
+    public String toWKT() {
+        if (coordinates != null && coordinates.size() > 0) {
+            return "MULTIPOINT("+ toWKT(coordinates) +  ")";
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/geojson/MultiPolygon.java
+++ b/src/main/java/org/geojson/MultiPolygon.java
@@ -25,4 +25,32 @@ public class MultiPolygon extends Geometry<List<List<LngLatAlt>>> {
 	public String toString() {
 		return "MultiPolygon{} " + super.toString();
 	}
+
+    public String toWKT() {
+        if (coordinates != null && coordinates.size() > 0) {
+            String wkt = "MULTIPOLYGON(";
+            boolean firstPolygon = true;
+            for (List<List<LngLatAlt>> polygon : coordinates) {
+                if (firstPolygon) {
+                    firstPolygon = false;
+                    wkt += "(";
+                } else {
+                    wkt += ",(";
+                }
+                boolean firstRing = true;
+                for (List<LngLatAlt> ring : polygon) {
+                    if (firstRing) {
+                        firstRing = false;
+                    } else {
+                        wkt += ",";
+                    }
+                    wkt += "("+ toWKT(ring) + ")";
+                }
+                wkt += ")";
+            }
+            wkt += ")";
+            return wkt;
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -1,5 +1,7 @@
 package org.geojson;
 
+import java.util.List;
+
 public class Point extends GeoJsonObject {
 
 	private LngLatAlt coordinates;
@@ -58,4 +60,11 @@ public class Point extends GeoJsonObject {
 	public String toString() {
 		return "Point{" + "coordinates=" + coordinates + "} " + super.toString();
 	}
+
+    public String toWKT() {
+        if (coordinates != null) {
+            return "POINT(" + coordinates.getLongitude() + " " + coordinates.getLatitude() + ")";
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/geojson/Polygon.java
+++ b/src/main/java/org/geojson/Polygon.java
@@ -63,4 +63,21 @@ public class Polygon extends Geometry<List<LngLatAlt>> {
 	public String toString() {
 		return "Polygon{} " + super.toString();
 	}
+
+    public String toWKT() {
+        List<LngLatAlt> exteriorRing = this.getExteriorRing();
+        if (exteriorRing != null) {
+            String wkt = "POLYGON(";
+            wkt += "(" + toWKT(exteriorRing) + ")";
+            List<List<LngLatAlt>> holes = this.getInteriorRings();
+            if (holes != null && holes.size() > 0) {
+                for (List<LngLatAlt> hole : holes) {
+                    wkt += ",(" + toWKT(hole) + ")";
+                }
+            }
+            wkt += ")";
+            return wkt;
+        }
+        return null;
+    }
 }

--- a/src/test/java/org/geojson/ToWktTest.java
+++ b/src/test/java/org/geojson/ToWktTest.java
@@ -1,0 +1,152 @@
+package org.geojson;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ToWktTest {
+
+    @Test
+    public void should_to_wkt_point() {
+        Point point = new Point(10, 30);
+
+        assertEquals(point.toWKT(), "POINT(10.0 30.0)");
+    }
+
+    @Test
+    public void should_to_wkt_multipoint() {
+        MultiPoint multiPoint = new MultiPoint();
+        multiPoint.add(new LngLatAlt(10, 40));
+        multiPoint.add(new LngLatAlt(40, 30));
+        multiPoint.add(new LngLatAlt(20, 20));
+        multiPoint.add(new LngLatAlt(30, 10));
+
+        assertEquals(multiPoint.toWKT(), "MULTIPOINT(10.0 40.0,40.0 30.0,20.0 20.0,30.0 10.0)");
+    }
+
+    @Test
+    public void should_to_wkt_linestring() {
+        LineString lineString = new LineString();
+        lineString.add(new LngLatAlt(30, 10));
+        lineString.add(new LngLatAlt(10, 30));
+        lineString.add(new LngLatAlt(40, 40));
+
+        assertEquals(lineString.toWKT(), "LINESTRING(30.0 10.0,10.0 30.0,40.0 40.0)");
+    }
+
+    @Test
+    public void should_to_wkt_multilinestring() {
+        MultiLineString multiLineString = new MultiLineString();
+        List<LngLatAlt> line = new ArrayList<LngLatAlt>();
+        line.add(new LngLatAlt(10, 10));
+        line.add(new LngLatAlt(20, 20));
+        line.add(new LngLatAlt(10, 40));
+        multiLineString.add(line);
+
+        line = new ArrayList<LngLatAlt>();
+        line.add(new LngLatAlt(40, 40));
+        line.add(new LngLatAlt(30, 30));
+        line.add(new LngLatAlt(40, 20));
+        line.add(new LngLatAlt(30, 10));
+        multiLineString.add(line);
+
+        assertEquals(multiLineString.toWKT(), "MULTILINESTRING((10.0 10.0,20.0 20.0,10.0 40.0),(40.0 40.0,30.0 30.0,40.0 20.0,30.0 10.0))");
+    }
+
+    @Test
+    public void should_to_wkt_polygon() {
+        Polygon polygon = new Polygon();
+        List<LngLatAlt> exteriorRing = new ArrayList<LngLatAlt>();
+        exteriorRing.add(new LngLatAlt(30, 10));
+        exteriorRing.add(new LngLatAlt(40, 40));
+        exteriorRing.add(new LngLatAlt(20, 40));
+        exteriorRing.add(new LngLatAlt(10, 20));
+        exteriorRing.add(new LngLatAlt(30, 10));
+        polygon.setExteriorRing(exteriorRing);
+
+        assertEquals(polygon.toWKT(), "POLYGON((30.0 10.0,40.0 40.0,20.0 40.0,10.0 20.0,30.0 10.0))");
+
+        polygon = new Polygon();
+        exteriorRing = new ArrayList<LngLatAlt>();
+        exteriorRing.add(new LngLatAlt(35, 10));
+        exteriorRing.add(new LngLatAlt(45, 45));
+        exteriorRing.add(new LngLatAlt(15, 40));
+        exteriorRing.add(new LngLatAlt(10, 20));
+        exteriorRing.add(new LngLatAlt(35, 10));
+        polygon.setExteriorRing(exteriorRing);
+
+        List<LngLatAlt> interiorRing = new ArrayList<LngLatAlt>();
+        interiorRing.add(new LngLatAlt(20, 30));
+        interiorRing.add(new LngLatAlt(35, 35));
+        interiorRing.add(new LngLatAlt(30, 20));
+        interiorRing.add(new LngLatAlt(20, 30));
+        polygon.addInteriorRing(interiorRing);
+
+        assertEquals(polygon.toWKT(), "POLYGON((35.0 10.0,45.0 45.0,15.0 40.0,10.0 20.0,35.0 10.0)," +
+                "(20.0 30.0,35.0 35.0,30.0 20.0,20.0 30.0))");
+
+    }
+
+    @Test
+    public void should_to_wkt_multipolygon() {
+        MultiPolygon multiPolygon = new MultiPolygon();
+
+        Polygon polygon = new Polygon();
+        List<LngLatAlt> exteriorRing = new ArrayList<LngLatAlt>();
+        exteriorRing.add(new LngLatAlt(30, 20));
+        exteriorRing.add(new LngLatAlt(45, 40));
+        exteriorRing.add(new LngLatAlt(10, 40));
+        exteriorRing.add(new LngLatAlt(30, 20));
+        polygon.setExteriorRing(exteriorRing);
+        multiPolygon.add(polygon);
+
+        polygon = new Polygon();
+        exteriorRing = new ArrayList<LngLatAlt>();
+        exteriorRing.add(new LngLatAlt(15, 5));
+        exteriorRing.add(new LngLatAlt(40, 10));
+        exteriorRing.add(new LngLatAlt(10, 20));
+        exteriorRing.add(new LngLatAlt(5, 10));
+        exteriorRing.add(new LngLatAlt(15, 5));
+        polygon.setExteriorRing(exteriorRing);
+        multiPolygon.add(polygon);
+
+        assertEquals(multiPolygon.toWKT(), "MULTIPOLYGON(((30.0 20.0,45.0 40.0,10.0 40.0,30.0 20.0))," +
+                "((15.0 5.0,40.0 10.0,10.0 20.0,5.0 10.0,15.0 5.0)))");
+
+        multiPolygon = new MultiPolygon();
+
+        polygon = new Polygon();
+        exteriorRing = new ArrayList<LngLatAlt>();
+        exteriorRing.add(new LngLatAlt(40, 40));
+        exteriorRing.add(new LngLatAlt(20, 45));
+        exteriorRing.add(new LngLatAlt(45, 30));
+        exteriorRing.add(new LngLatAlt(40, 40));
+        polygon.setExteriorRing(exteriorRing);
+        multiPolygon.add(polygon);
+
+        polygon = new Polygon();
+        exteriorRing = new ArrayList<LngLatAlt>();
+        exteriorRing.add(new LngLatAlt(20, 35));
+        exteriorRing.add(new LngLatAlt(10, 30));
+        exteriorRing.add(new LngLatAlt(10, 10));
+        exteriorRing.add(new LngLatAlt(30, 5));
+        exteriorRing.add(new LngLatAlt(45, 20));
+        exteriorRing.add(new LngLatAlt(20, 35));
+        polygon.setExteriorRing(exteriorRing);
+
+        List<LngLatAlt> interiorRing = new ArrayList<LngLatAlt>();
+        interiorRing.add(new LngLatAlt(30, 20));
+        interiorRing.add(new LngLatAlt(20, 15));
+        interiorRing.add(new LngLatAlt(20, 25));
+        interiorRing.add(new LngLatAlt(30, 20));
+        polygon.addInteriorRing(interiorRing);
+        multiPolygon.add(polygon);
+
+        assertEquals(multiPolygon.toWKT(), "MULTIPOLYGON(((40.0 40.0,20.0 45.0,45.0 30.0,40.0 40.0))," +
+                "((20.0 35.0,10.0 30.0,10.0 10.0,30.0 5.0,45.0 20.0,20.0 35.0),(30.0 20.0,20.0 15.0,20.0 25.0,30.0 20.0)))");
+    }
+
+}


### PR DESCRIPTION
Hello, 
This library is really great and has make me saved a bunch of time. That's why I wanted to contributed in return and here is my pull-request. 

WKT format (http://en.wikipedia.org/wiki/Well-known_text) is used by several other frameworks and tools around and I've had to transform GeoJSON geometries from and into WKT. In this pull request I've added the implementation of a new method `String toWKT()` into the following geometries : 
* Point
* MultiPoint
* LineString
* MultiLineString
* Polygon
* MultiPolygon

If you enjoy this PR I can if you are interested in make another one in order to implement new static methods on these geometries like `Point parseWKT(String wkt)` in the Point class, `MultiPoint parseWKT(String wkt)` in the MultiPoint class, etc.