### PR TITLE
Fix for GeometryCollection not being a valid geometry 

### DIFF
--- a/src/main/java/org/geojson/GeoJsonObject.java
+++ b/src/main/java/org/geojson/GeoJsonObject.java
@@ -12,7 +12,8 @@ import java.util.Arrays;
 
 @JsonTypeInfo(property = "type", use = Id.NAME)
 @JsonSubTypes({ @Type(Feature.class), @Type(Polygon.class), @Type(MultiPolygon.class), @Type(FeatureCollection.class),
-		@Type(Point.class), @Type(MultiPoint.class), @Type(MultiLineString.class), @Type(LineString.class) })
+		@Type(Point.class), @Type(MultiPoint.class), @Type(MultiLineString.class), @Type(LineString.class),
+                @Type(GeometryCollection.class) })
 @JsonInclude(Include.NON_NULL)
 public abstract class GeoJsonObject implements Serializable {
 


### PR DESCRIPTION
GeometryCollection was not properly marshalling when placed in a Feature. Changes added the right annotation.

Example of a JSON message that was not marshaling correctly before the change:
```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "GeometryCollection",
        "geometries": [
          {
            "type": "Point",
            "coordinates": [100.0, 0.0]
          }
        ]
      }
    }
  ]
}
```