### PR TITLE
add GeoJsonObjectVisitor.Adapter

### DIFF
--- a/src/main/java/org/geojson/GeoJsonObjectVisitor.java
+++ b/src/main/java/org/geojson/GeoJsonObjectVisitor.java
@@ -25,4 +25,59 @@ public interface GeoJsonObjectVisitor<T> {
 	T visit(MultiPoint geoJsonObject);
 
 	T visit(LineString geoJsonObject);
+
+	/**
+	 * An abstract adapter class for visiting GeoJson objects.
+	 * The methods in this class are empty.
+	 * This class exists as convenience for creating listener objects.
+	 *
+	 * @param <T> Return type of the visitor
+   */
+	class Adapter<T> implements GeoJsonObjectVisitor<T> {
+
+		@Override
+		public T visit(GeometryCollection geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(FeatureCollection geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(Point geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(Feature geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(MultiLineString geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(Polygon geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(MultiPolygon geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(MultiPoint geoJsonObject) {
+			return null;
+		}
+
+		@Override
+		public T visit(LineString geoJsonObject) {
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
I think that this library needs to provide an Adapter for the GeoJsonObjectVisitor.

Instead of adding a new class called GeoJsonObjectVisitor, I decided to add GeoJsonObjectVisitor.Adapter

I think that when an adapter is right inside its interface, the namespace is cleaner and its usage more intuitive (this is something I learned from the IntelliJ sources).