### PR TITLE
Support for additional elements in coordinate

### DIFF
--- a/src/main/java/org/geojson/LngLatAlt.java
+++ b/src/main/java/org/geojson/LngLatAlt.java
@@ -45,11 +45,8 @@ public class LngLatAlt implements Serializable{
 		this.latitude = latitude;
 		this.altitude = altitude;
 
-		if (additionalElements != null ) {
-			this.additionalElements = additionalElements;
-		} else {
-			this.additionalElements = new double[0];
-		}
+		setAdditionalElements(additionalElements);
+		checkAltitudeAndAdditionalElements();
 	}
 
 	public boolean hasAltitude() {
@@ -82,6 +79,7 @@ public class LngLatAlt implements Serializable{
 
 	public void setAltitude(double altitude) {
 		this.altitude = altitude;
+		checkAltitudeAndAdditionalElements();
 	}
 
 	public double[] getAdditionalElements() {
@@ -94,6 +92,17 @@ public class LngLatAlt implements Serializable{
 		} else {
 			this.additionalElements = new double[0];
 		}
+
+		for(double element : this.additionalElements) {
+			if (Double.isNaN(element)) {
+				throw new IllegalArgumentException("No additional elements may be NaN.");
+			}
+			if (Double.isInfinite(element)) {
+				throw new IllegalArgumentException("No additional elements may be infinite.");
+			}
+		}
+
+		checkAltitudeAndAdditionalElements();
 	}
 
 	@Override
@@ -145,5 +154,11 @@ public class LngLatAlt implements Serializable{
 		s += '}';
 
 		return s;
+	}
+
+	private void checkAltitudeAndAdditionalElements() {
+		if (!hasAltitude() && hasAdditionalElements()) {
+			throw new IllegalArgumentException("Additional Elements are only valid if Altitude is also provided.");
+		}
 	}
 }

--- a/src/main/java/org/geojson/LngLatAlt.java
+++ b/src/main/java/org/geojson/LngLatAlt.java
@@ -6,6 +6,7 @@ import org.geojson.jackson.LngLatAltDeserializer;
 import org.geojson.jackson.LngLatAltSerializer;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 @JsonDeserialize(using = LngLatAltDeserializer.class)
 @JsonSerialize(using = LngLatAltSerializer.class)
@@ -14,6 +15,7 @@ public class LngLatAlt implements Serializable{
 	private double longitude;
 	private double latitude;
 	private double altitude = Double.NaN;
+	private double[] additionalElements = new double[0];
 
 	public LngLatAlt() {
 	}
@@ -29,8 +31,33 @@ public class LngLatAlt implements Serializable{
 		this.altitude = altitude;
 	}
 
+	/**
+	 * Construct a LngLatAlt with additional elements.
+	 * The specification allows for any number of additional elements in a position, after lng, lat, alt.
+	 * http://geojson.org/geojson-spec.html#positions
+	 * @param longitude The longitude.
+	 * @param latitude The latitude.
+	 * @param altitude The altitude.
+	 * @param additionalElements The additional elements.
+     */
+	public LngLatAlt(double longitude, double latitude, double altitude, double... additionalElements) {
+		this.longitude = longitude;
+		this.latitude = latitude;
+		this.altitude = altitude;
+
+		if (additionalElements != null ) {
+			this.additionalElements = additionalElements;
+		} else {
+			this.additionalElements = new double[0];
+		}
+	}
+
 	public boolean hasAltitude() {
 		return !Double.isNaN(altitude);
+	}
+
+	public boolean hasAdditionalElements() {
+		return additionalElements.length > 0;
 	}
 
 	public double getLongitude() {
@@ -57,6 +84,18 @@ public class LngLatAlt implements Serializable{
 		this.altitude = altitude;
 	}
 
+	public double[] getAdditionalElements() {
+		return additionalElements;
+	}
+
+	public void setAdditionalElements(double... additionalElements) {
+		if (additionalElements != null) {
+			this.additionalElements = additionalElements;
+		} else {
+			this.additionalElements = new double[0];
+		}
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -67,7 +106,8 @@ public class LngLatAlt implements Serializable{
 		}
 		LngLatAlt lngLatAlt = (LngLatAlt)o;
 		return Double.compare(lngLatAlt.latitude, latitude) == 0 && Double.compare(lngLatAlt.longitude, longitude) == 0
-				&& Double.compare(lngLatAlt.altitude, altitude) == 0;
+				&& Double.compare(lngLatAlt.altitude, altitude) == 0 &&
+				Arrays.equals(lngLatAlt.getAdditionalElements(), additionalElements);
 	}
 
 	@Override
@@ -78,11 +118,32 @@ public class LngLatAlt implements Serializable{
 		result = 31 * result + (int)(temp ^ (temp >>> 32));
 		temp = Double.doubleToLongBits(altitude);
 		result = 31 * result + (int)(temp ^ (temp >>> 32));
+		for(double element : additionalElements) {
+			temp = Double.doubleToLongBits(element);
+			result = 31 * result + (int) (temp ^ (temp >>> 32));
+		}
 		return result;
 	}
 
 	@Override
 	public String toString() {
-		return "LngLatAlt{" + "longitude=" + longitude + ", latitude=" + latitude + ", altitude=" + altitude + '}';
+		String s =  "LngLatAlt{" + "longitude=" + longitude + ", latitude=" + latitude + ", altitude=" + altitude;
+
+		if (hasAdditionalElements()) {
+			s += ", additionalElements=[";
+
+			String suffix = "";
+			for (Double element : additionalElements) {
+				if (element != null) {
+					s += suffix + element;
+					suffix = ", ";
+				}
+			}
+			s += ']';
+		}
+
+		s += '}';
+
+		return s;
 	}
 }

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -19,6 +19,10 @@ public class Point extends GeoJsonObject {
 		coordinates = new LngLatAlt(longitude, latitude, altitude);
 	}
 
+	public Point(double longitude, double latitude, double altitude, double... additionalElements) {
+		coordinates = new LngLatAlt(longitude, latitude, altitude, additionalElements);
+	}
+
 	public LngLatAlt getCoordinates() {
 		return coordinates;
 	}

--- a/src/main/java/org/geojson/jackson/LngLatAltDeserializer.java
+++ b/src/main/java/org/geojson/jackson/LngLatAltDeserializer.java
@@ -1,6 +1,8 @@
 package org.geojson.jackson;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.geojson.LngLatAlt;
 
@@ -28,8 +30,21 @@ public class LngLatAltDeserializer extends JsonDeserializer<LngLatAlt> {
 		node.setLongitude(extractDouble(jp, ctxt, false));
 		node.setLatitude(extractDouble(jp, ctxt, false));
 		node.setAltitude(extractDouble(jp, ctxt, true));
-		if (jp.hasCurrentToken() && jp.getCurrentToken() != JsonToken.END_ARRAY)
-			jp.nextToken();
+
+		List<Double> additionalElementsList = new ArrayList<Double>();
+		while (jp.hasCurrentToken() && jp.getCurrentToken() != JsonToken.END_ARRAY) {
+			double element = extractDouble(jp, ctxt, true);
+			if (!Double.isNaN(element)) {
+				additionalElementsList.add(element);
+			}
+		}
+
+		double[] additionalElements = new double[additionalElementsList.size()];
+		for(int i = 0; i < additionalElements.length; i++) {
+			additionalElements[i] = additionalElementsList.get(i);
+		}
+		node.setAdditionalElements(additionalElements);
+
 		return node;
 	}
 

--- a/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
+++ b/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
@@ -49,8 +49,15 @@ public class LngLatAltSerializer extends JsonSerializer<LngLatAlt> {
 		jgen.writeStartArray();
 		jgen.writeNumber(fastDoubleToString(value.getLongitude(), 9));
 		jgen.writeNumber(fastDoubleToString(value.getLatitude(), 9));
-		if (value.hasAltitude())
+		if (value.hasAltitude()) {
 			jgen.writeNumber(value.getAltitude());
+
+			for(Double d : value.getAdditionalElements()) {
+				if (d != null) {
+					jgen.writeNumber(d);
+				}
+			}
+		}
 		jgen.writeEndArray();
 	}
 }

--- a/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
+++ b/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
@@ -52,10 +52,8 @@ public class LngLatAltSerializer extends JsonSerializer<LngLatAlt> {
 		if (value.hasAltitude()) {
 			jgen.writeNumber(value.getAltitude());
 
-			for(Double d : value.getAdditionalElements()) {
-				if (d != null) {
-					jgen.writeNumber(d);
-				}
+			for(double d : value.getAdditionalElements()) {
+				jgen.writeNumber(d);
 			}
 		}
 		jgen.writeEndArray();

--- a/src/test/java/org/geojson/LngLatAltTest.java
+++ b/src/test/java/org/geojson/LngLatAltTest.java
@@ -32,4 +32,44 @@ public class LngLatAltTest {
 		LngLatAlt second = new LngLatAlt(14.D, 13.D, 16D);
 		Assert.assertNotEquals(second, first);
 	}
+
+	@Test
+	public void should_LngLatAlt_equals_with_additional_elements() {
+		LngLatAlt first = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D);
+		LngLatAlt second = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D);
+		Assert.assertEquals(second, first);
+		Assert.assertEquals(second.hashCode(), first.hashCode());
+	}
+
+	@Test
+	public void should_LngLatAlt_equals_with_additional_elements_and_null() {
+		LngLatAlt first = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D);
+		LngLatAlt second = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D);
+		Assert.assertEquals(second, first);
+		Assert.assertEquals(second.hashCode(), first.hashCode());
+	}
+
+	@Test
+	public void should_not_LngLatAlt_equals_without_additional_elements() {
+		LngLatAlt first = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D);
+		LngLatAlt second = new LngLatAlt(14.D, 14.D, 15D);
+		Assert.assertNotEquals(second, first);
+		Assert.assertNotEquals(second.hashCode(), first.hashCode());
+	}
+
+	@Test
+	public void should_not_LngLatAlt_equals_with_additional_elements_in_different_order() {
+		LngLatAlt first = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D);
+		LngLatAlt second = new LngLatAlt(14.D, 14.D, 15D, 17D, 16D);
+		Assert.assertNotEquals(second, first);
+		Assert.assertNotEquals(second.hashCode(), first.hashCode());
+	}
+
+	@Test
+	public void should_not_LngLatAlt_equals_with_additional_elements_and_different_size() {
+		LngLatAlt first = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D);
+		LngLatAlt second = new LngLatAlt(14.D, 14.D, 15D, 16D, 17D, 18D);
+		Assert.assertNotEquals(second, first);
+		Assert.assertNotEquals(second.hashCode(), first.hashCode());
+	}
 }

--- a/src/test/java/org/geojson/LngLatAltTest.java
+++ b/src/test/java/org/geojson/LngLatAltTest.java
@@ -72,4 +72,113 @@ public class LngLatAltTest {
 		Assert.assertNotEquals(second, first);
 		Assert.assertNotEquals(second.hashCode(), first.hashCode());
 	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_alt_not_specified_in_constructor() {
+		try {
+			new LngLatAlt(14.D, 14.D, Double.NaN, 16D, 17D);
+			Assert.fail("Additional elements are not allowed if altitude is Nan.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_alt_set_to_Nan_with_additional_elements() {
+		LngLatAlt lngLatAlt = new LngLatAlt(14.D, 14.D, 15.D, 16D, 17D);
+
+		try {
+			lngLatAlt.setAltitude(Double.NaN);
+			Assert.fail("Additional elements are not allowed if altitude is Nan.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_additional_elements_set_with_missing_alt() {
+		LngLatAlt lngLatAlt = new LngLatAlt(14.D, 14.D);
+
+		try {
+			lngLatAlt.setAdditionalElements(42);
+			Assert.fail("Additional elements are not allowed if altitude is Nan.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_additional_elements_set_with_Nan_alt() {
+		LngLatAlt lngLatAlt = new LngLatAlt(14.D, 14.D, Double.NaN);
+
+		try {
+			lngLatAlt.setAdditionalElements(42);
+			Assert.fail("Additional elements are not allowed if altitude is Nan.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_any_additional_elements_constructed_to_Nan() {
+		try {
+			new LngLatAlt(14.D, 14.D, 15.D, 16.D, Double.NaN, 17.D);
+			Assert.fail("Additional elements are not allowed to be Nan.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_any_additional_elements_constructed_to_Positive_Infinity() {
+		try {
+			new LngLatAlt(14.D, 14.D, 15.D, 16.D, Double.POSITIVE_INFINITY, 17.D);
+			Assert.fail("Additional elements are not allowed to be positive infinity.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_any_additional_elements_constructed_to_Negative_Infinity() {
+		try {
+			new LngLatAlt(14.D, 14.D, 15.D, 16.D, Double.NEGATIVE_INFINITY, 17.D);
+			Assert.fail("Additional elements are not allowed to be positive infinity.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_any_additional_elements_set_to_Nan() {
+		LngLatAlt lngLatAlt = new LngLatAlt(14.D, 14.D, 15.D);
+		try {
+			lngLatAlt.setAdditionalElements(16.D, Double.NaN, 17.D);
+			Assert.fail("Additional elements are not allowed to be Nan.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_any_additional_elements_set_to_Positive_Infinity() {
+		LngLatAlt lngLatAlt = new LngLatAlt(14.D, 14.D, 15.D);
+		try {
+			lngLatAlt.setAdditionalElements(16.D, Double.POSITIVE_INFINITY, 17.D);
+			Assert.fail("Additional elements are not allowed to be positive infinity.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
+
+	@Test
+	public void should_LngLatAlt_throw_if_any_additional_elements_set_to_Negative_Infinity() {
+		LngLatAlt lngLatAlt = new LngLatAlt(14.D, 14.D, 15.D);
+		try {
+			lngLatAlt.setAdditionalElements(16.D, Double.NEGATIVE_INFINITY, 17.D);
+			Assert.fail("Additional elements are not allowed to be positive infinity.");
+		} catch (IllegalArgumentException e) {
+			Assert.assertTrue("Expected exception.", true);
+		}
+	}
 }

--- a/src/test/java/org/geojson/ToStringTest.java
+++ b/src/test/java/org/geojson/ToStringTest.java
@@ -32,6 +32,22 @@ public class ToStringTest {
 	}
 
 	@Test
+	public void itShouldToStringPointWithAdditionalElements() {
+		Point geometry = new Point(10, 20, 30, 40D, 50D);
+		assertEquals(
+				"Point{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=30.0, additionalElements=[40.0, 50.0]}} GeoJsonObject{}",
+				geometry.toString());
+	}
+
+	@Test
+	public void itShouldToStringPointWithAdditionalElementsAndIgnoreNulls() {
+		Point geometry = new Point(10, 20, 30, 40D, 50D);
+		assertEquals(
+				"Point{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=30.0, additionalElements=[40.0, 50.0]}} GeoJsonObject{}",
+				geometry.toString());
+	}
+
+	@Test
 	public void itShouldToStringPolygon() throws Exception {
 		Polygon geometry = new Polygon(new LngLatAlt(10, 20), new LngLatAlt(30, 40), new LngLatAlt(10, 40),
 				new LngLatAlt(10, 20));

--- a/src/test/java/org/geojson/jackson/PointTest.java
+++ b/src/test/java/org/geojson/jackson/PointTest.java
@@ -1,10 +1,14 @@
 package org.geojson.jackson;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geojson.GeoJsonObject;
 import org.geojson.LngLatAlt;
 import org.geojson.Point;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
@@ -12,14 +16,21 @@ public class PointTest {
 
 	private ObjectMapper mapper = new ObjectMapper();
 
-	public static void assertLngLatAlt(double expectedLongitue, double expectedLatitude, double expectedAltitude,
-			LngLatAlt point) {
-		assertEquals(expectedLongitue, point.getLongitude(), 0.00001);
+	public static void assertLngLatAlt(double expectedLongitude, double expectedLatitude, double expectedAltitude,
+									   LngLatAlt point) {
+		assertLngLatAlt(expectedLongitude, expectedLatitude, expectedAltitude, new double[0], point);
+	}
+
+	public static void assertLngLatAlt(double expectedLongitude, double expectedLatitude, double expectedAltitude,
+									   double[] expectedAdditionalElements, LngLatAlt point) {
+		assertEquals(expectedLongitude, point.getLongitude(), 0.00001);
 		assertEquals(expectedLatitude, point.getLatitude(), 0.00001);
-		if (Double.isNaN(expectedAltitude))
+		if (Double.isNaN(expectedAltitude)) {
 			assertFalse(point.hasAltitude());
-		else
+		} else {
 			assertEquals(expectedAltitude, point.getAltitude(), 0.00001);
+			assertTrue(Arrays.equals(expectedAdditionalElements, point.getAdditionalElements()));
+		}
 	}
 
 	@Test
@@ -51,6 +62,28 @@ public class PointTest {
 	public void itShouldSerializeAPointWithAltitude() throws Exception {
 		Point point = new Point(100, 0, 256);
 		assertEquals("{\"type\":\"Point\",\"coordinates\":[100.0,0.0,256.0]}",
+				mapper.writeValueAsString(point));
+	}
+
+	@Test
+	public void itShouldDeserializeAPointWithAdditionalAttributes() throws IOException {
+		GeoJsonObject value = mapper.readValue("{\"type\":\"Point\",\"coordinates\":[100.0,5.0,123,456,789.2]}",
+				GeoJsonObject.class);
+		Point point = (Point)value;
+		assertLngLatAlt(100, 5, 123, new double[] {456d, 789.2}, point.getCoordinates());
+	}
+
+	@Test
+	public void itShouldSerializeAPointWithAdditionalAttributes() throws JsonProcessingException {
+		Point point = new Point(100, 0, 256, 345d, 678d);
+		assertEquals("{\"type\":\"Point\",\"coordinates\":[100.0,0.0,256.0,345.0,678.0]}",
+				mapper.writeValueAsString(point));
+	}
+
+	@Test
+	public void itShouldSerializeAPointWithAdditionalAttributesAndNull() throws JsonProcessingException {
+		Point point = new Point(100, 0, 256, 345d, 678d);
+		assertEquals("{\"type\":\"Point\",\"coordinates\":[100.0,0.0,256.0,345.0,678.0]}",
 				mapper.writeValueAsString(point));
 	}
 }


### PR DESCRIPTION
The Positions portion of the GeoJson specification allows for more than three elements. This change optionally allows an arbitrary number of elements after altitude.