### PR TITLE
Add fix to LngLatAlt deserilizer for mongo

### DIFF
--- a/src/main/java/org/geojson/jackson/LngLatAltDeserializer.java
+++ b/src/main/java/org/geojson/jackson/LngLatAltDeserializer.java
@@ -68,9 +68,11 @@ public class LngLatAltDeserializer extends JsonDeserializer<LngLatAlt> {
 					return jp.getDoubleValue();
 				case VALUE_NUMBER_INT:
 					return jp.getLongValue();
+				case VALUE_STRING:
+					return jp.getValueAsDouble();
 				default:
 					throw ctxt.mappingException("Unexpected token (" + token.name()
-							+ ") when binding data into LngLatAlt ");
+							+ ") when binding data into LngLatAlt");
 			}
 		}
 	}

--- a/src/test/java/org/geojson/jackson/LngLatAltDeserializerTest.java
+++ b/src/test/java/org/geojson/jackson/LngLatAltDeserializerTest.java
@@ -1,0 +1,21 @@
+package org.geojson.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.geojson.LngLatAlt;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by babbleshack on 27/11/16.
+ */
+public class LngLatAltDeserializerTest {
+    @Test
+    public void deserializeMongoLngLatAlt() throws Exception {
+        LngLatAlt lngLatAlt = new LngLatAlt(10D, 15D, 5);
+        String lngLatAltJson = new ObjectMapper().writeValueAsString(lngLatAlt);
+        lngLatAltJson.replace("10.0", "\"10.0\"");
+        lngLatAltJson.replace("15.0", "\"15.0\"");
+        LngLatAlt lngLatAlt1 = new ObjectMapper().readValue(lngLatAltJson, LngLatAlt.class);
+        Assert.assertTrue(lngLatAlt.equals(lngLatAlt));
+    }
+}


### PR DESCRIPTION
Adds a third case statement encase the json string contains string
coordinate values instead of a double

Fix for issue #28 