### PR TITLE
Fix for LngLatAltSerializer so that it produces an array of doubles rather than strings

### DIFF
--- a/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
+++ b/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
@@ -12,43 +12,12 @@ public class LngLatAltSerializer extends JsonSerializer<LngLatAlt> {
 
 	public static final long POW10[] = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
 
-	/**
-	 * The following must convert double to String in a much more efficient way then Double.toString()
-	 *
-	 * @See http://stackoverflow.com/questions/10553710/fast-double-to-string-conversion-with-given-precision
-	 * @param val
-	 * @param precision
-	 * @return
-	 */
-	protected static String fastDoubleToString(double val, int precision) {
-		StringBuilder sb = new StringBuilder();
-		if (val < 0) {
-			sb.append('-');
-			val = -val;
-		}
-		long exp = POW10[precision];
-		long lval = (long)(val * exp + 0.5);
-		sb.append(lval / exp).append('.');
-		long fval = lval % exp;
-		for (int p = precision - 1; p > 0 && fval < POW10[p] && fval>0; p--) {
-			sb.append('0');
-		}
-		sb.append(fval);
-		int i = sb.length()-1;
-		while(sb.charAt(i)=='0' && sb.charAt(i-1)!='.')
-		{
-			sb.deleteCharAt(i);
-			i--;
-		}
-		return sb.toString();
-	}
-
 	@Override
 	public void serialize(LngLatAlt value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
 			JsonProcessingException {
 		jgen.writeStartArray();
-		jgen.writeNumber(fastDoubleToString(value.getLongitude(), 9));
-		jgen.writeNumber(fastDoubleToString(value.getLatitude(), 9));
+		jgen.writeNumber(value.getLongitude());
+		jgen.writeNumber(value.getLatitude());
 		if (value.hasAltitude()) {
 			jgen.writeNumber(value.getAltitude());
 


### PR DESCRIPTION
If you look at the geoJson specifications position data should be given as an array of doubles not strings.
http://geojson.org/geojson-spec.html#geometry-objects

Theres was also the problem that the Double to String conversion in LngLatAltSerializer performed on lng and lat but not alt. So a 3d point ends up with two strings and a double.

I came accorss this problem when I was trying to use geojson generated by this api with MongoDB. MongoDB is designed to work wth the geoJson spec and so cannot create indexes for the generated geoJson as it expects arrays of Doubles not Strings when dealing with locations.

Ive corrected these problems by removing the fastDoubleToString method from the LngLatAltSerializer.