### PR TITLE
Get rid of explicit dependency to jackson-core...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>2.7.3</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.7.3</version>
 		</dependency>


### PR DESCRIPTION
... because "jackson-databind" already depends on "jackson-core" and because they both evolve at the same time.