### PR TITLE
LngLatAltSerializer#serialize throws useless JsonProcessingException

### DIFF
--- a/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
+++ b/src/main/java/org/geojson/jackson/LngLatAltSerializer.java
@@ -5,26 +5,20 @@ import java.io.IOException;
 import org.geojson.LngLatAlt;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
-public class LngLatAltSerializer extends JsonSerializer<LngLatAlt>
-{
+public class LngLatAltSerializer extends JsonSerializer<LngLatAlt> {
 
     @Override
-    public void serialize(LngLatAlt value, JsonGenerator jgen, SerializerProvider provider)
-        throws IOException, JsonProcessingException
-    {
+    public void serialize(LngLatAlt value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
         jgen.writeStartArray();
         jgen.writeNumber(value.getLongitude());
         jgen.writeNumber(value.getLatitude());
-        if (value.hasAltitude())
-        {
+        if (value.hasAltitude()) {
             jgen.writeNumber(value.getAltitude());
 
-            for (double d : value.getAdditionalElements())
-            {
+            for (double d : value.getAdditionalElements()) {
                 jgen.writeNumber(d);
             }
         }


### PR DESCRIPTION
IntelliJ code inspection warns me that: "There is a more general exception, 'java.io.IOException', in the throws list already"

Declaring "JsonProcessingException" in the throws list is thus useless! This is a more general problem of jackson-databind but I think we can change the method signature without introducing regressions.

What do you think?