### PR TITLE
(#45) Implemented realtime bounding box calculation.

### DIFF
--- a/src/main/java/org/geojson/Feature.java
+++ b/src/main/java/org/geojson/Feature.java
@@ -10,7 +10,7 @@ public class Feature extends GeoJsonObject {
 	@JsonInclude(JsonInclude.Include.ALWAYS)
 	private Map<String, Object> properties = new HashMap<String, Object>();
 	@JsonInclude(JsonInclude.Include.ALWAYS)
-	private GeoJsonObject geometry;
+	private GeoJsonObject geometry = null ;
 	private String id;
 
 	public void setProperty(String key, Object value) {
@@ -26,14 +26,20 @@ public class Feature extends GeoJsonObject {
 		return properties;
 	}
 
-	public void setProperties(Map<String, Object> properties) {
-		this.properties = properties;
+	public void setProperties( Map<String,Object> properties )
+	{
+		if( properties == null ) this.properties.clear() ;
+		else this.properties = properties ;
 	}
 
-	public GeoJsonObject getGeometry() {
-		return geometry;
-	}
+	public GeoJsonObject getGeometry()
+	{ return geometry ; }
 
+	/**
+	 * Sets the geometry of the feature.
+	 * Implies recalculation of the feature's bounding box.
+	 * @param geometry the new feature geometry
+	 */
 	public void setGeometry( GeoJsonObject geometry )
 	{
 		this.geometry = geometry ;
@@ -51,7 +57,8 @@ public class Feature extends GeoJsonObject {
 	@Override
 	public double[] calculateBounds()
 	{
-		this.setBbox( this.getGeometry().calculateBounds() ) ;
+		if( this.geometry == null ) this.setBbox(null) ;
+		else this.setBbox( this.getGeometry().getBbox() ) ;
 		return this.getBbox() ;
 	}
 

--- a/src/main/java/org/geojson/Feature.java
+++ b/src/main/java/org/geojson/Feature.java
@@ -34,8 +34,10 @@ public class Feature extends GeoJsonObject {
 		return geometry;
 	}
 
-	public void setGeometry(GeoJsonObject geometry) {
-		this.geometry = geometry;
+	public void setGeometry( GeoJsonObject geometry )
+	{
+		this.geometry = geometry ;
+		this.calculateBounds() ;
 	}
 
 	public String getId() {

--- a/src/main/java/org/geojson/Feature.java
+++ b/src/main/java/org/geojson/Feature.java
@@ -47,6 +47,13 @@ public class Feature extends GeoJsonObject {
 	}
 
 	@Override
+	public double[] calculateBounds()
+	{
+		this.setBbox( this.getGeometry().calculateBounds() ) ;
+		return this.getBbox() ;
+	}
+
+	@Override
 	public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
 		return geoJsonObjectVisitor.visit(this);
 	}

--- a/src/main/java/org/geojson/FeatureCollection.java
+++ b/src/main/java/org/geojson/FeatureCollection.java
@@ -1,9 +1,6 @@
 package org.geojson;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 public class FeatureCollection extends GeoJsonObject implements Iterable<Feature> {
 
@@ -13,32 +10,56 @@ public class FeatureCollection extends GeoJsonObject implements Iterable<Feature
 		return features;
 	}
 
+	/**
+	 * Sets a new list of features for the collection.
+	 * Implies a recalculation of the bounding box around the collection.
+	 * @param features the new list of features
+	 */
 	public void setFeatures( List<Feature> features )
 	{
-		this.features = features ;
+		if( features == null ) this.features.clear() ;
+		else this.features = features ;
 		this.calculateBounds() ;
 	}
 
 	@Override
 	public double[] calculateBounds()
 	{
-		double[] box = STARTING_BOUNDS.clone() ;
-		for( Feature f : this.getFeatures() )
-			accumulateBounds( box, f.calculateBounds() ) ;
-		this.setBbox(box) ;
+		if( this.features.isEmpty() )
+			this.setBbox(null) ;
+		else
+		{
+			double[] box = STARTING_BOUNDS.clone() ;
+			for( Feature f : this.getFeatures() )
+				accumulateBounds( box, f.getBbox() ) ;
+			this.setBbox(box) ;
+		}
 		return this.getBbox() ;
 	}
 
+	/**
+	 * Adds a feature to the collection.
+	 * Implies a recalculation of the bounding box around the collection.
+	 * @param feature the feature to be added
+	 * @return (fluid)
+	 */
 	public FeatureCollection add( Feature feature )
 	{
+		if( feature == null ) return this ; // trivially
 		features.add(feature) ;
 		this.setBbox( accumulateBounds(
 				this.getBbox(), feature.calculateBounds() )) ;
 		return this ;
 	}
 
+	/**
+	 * Adds a collection of features to this collection.
+	 * Implies a recalculation of the bounding box around the collection.
+	 * @param features the features to be added
+	 */
 	public void addAll( Collection<Feature> features )
 	{
+		if( features == null || features.isEmpty() ) return ; // trivially
 		this.features.addAll(features) ;
 		this.calculateBounds() ;
 	}

--- a/src/main/java/org/geojson/FeatureCollection.java
+++ b/src/main/java/org/geojson/FeatureCollection.java
@@ -17,6 +17,10 @@ public class FeatureCollection extends GeoJsonObject implements Iterable<Feature
 		this.features = features;
 	}
 
+	@Override
+	public double[] calculateBounds()
+	{ return null ; }
+
 	public FeatureCollection add(Feature feature) {
 		features.add(feature);
 		return this;

--- a/src/main/java/org/geojson/FeatureCollection.java
+++ b/src/main/java/org/geojson/FeatureCollection.java
@@ -13,21 +13,34 @@ public class FeatureCollection extends GeoJsonObject implements Iterable<Feature
 		return features;
 	}
 
-	public void setFeatures(List<Feature> features) {
-		this.features = features;
+	public void setFeatures( List<Feature> features )
+	{
+		this.features = features ;
+		this.calculateBounds() ;
 	}
 
 	@Override
 	public double[] calculateBounds()
-	{ return null ; }
-
-	public FeatureCollection add(Feature feature) {
-		features.add(feature);
-		return this;
+	{
+		double[] box = STARTING_BOUNDS.clone() ;
+		for( Feature f : this.getFeatures() )
+			accumulateBounds( box, f.calculateBounds() ) ;
+		this.setBbox(box) ;
+		return this.getBbox() ;
 	}
 
-	public void addAll(Collection<Feature> features) {
-		this.features.addAll(features);
+	public FeatureCollection add( Feature feature )
+	{
+		features.add(feature) ;
+		this.setBbox( accumulateBounds(
+				this.getBbox(), feature.calculateBounds() )) ;
+		return this ;
+	}
+
+	public void addAll( Collection<Feature> features )
+	{
+		this.features.addAll(features) ;
+		this.calculateBounds() ;
 	}
 
 	@Override

--- a/src/main/java/org/geojson/GeoJsonObject.java
+++ b/src/main/java/org/geojson/GeoJsonObject.java
@@ -1,5 +1,6 @@
 package org.geojson;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -23,13 +24,23 @@ public abstract class GeoJsonObject implements Serializable
 	private double[] bbox;
 
 	/**
+	 * Starting bounds to guarantee that the various {@code calculateBounds}
+	 * methods will work out correctly.
+	 */
+	protected static final double[] STARTING_BOUNDS =
+		{
+			Double.MAX_VALUE, Double.MAX_VALUE,
+			Double.MIN_VALUE, Double.MIN_VALUE
+		} ;
+
+	/**
 	 * Calculates the bounding box around a list of points.
 	 * @param points a list of points that compose a polygon
 	 * @return a bounding box
 	 */
 	public static double[] calculateBounds( List<LngLatAlt> points )
 	{
-		double[] box = { 0.0d, 0.0d, 0.0d, 0.0d } ;
+		double[] box = STARTING_BOUNDS.clone() ;
 		for( LngLatAlt point : points )
 		{
 			double longitude = point.getLongitude() ;
@@ -56,6 +67,7 @@ public abstract class GeoJsonObject implements Serializable
 	@SuppressWarnings("UnusedReturnValue")
 	public static double[] accumulateBounds( double[] currentBox, double[] newData )
 	{
+		if( currentBox == null ) currentBox = STARTING_BOUNDS.clone() ;
 		if( Double.compare( newData[0], currentBox[0] ) < 0 )
 			currentBox[0] = newData[0] ;
 		if( Double.compare( newData[1], currentBox[1] ) < 0 )
@@ -75,10 +87,12 @@ public abstract class GeoJsonObject implements Serializable
 		this.crs = crs;
 	}
 
+	@JsonIgnore
 	public double[] getBbox() {
 		return bbox;
 	}
 
+	@JsonIgnore
 	public void setBbox(double[] bbox) {
 		this.bbox = bbox;
 	}

--- a/src/main/java/org/geojson/GeoJsonObject.java
+++ b/src/main/java/org/geojson/GeoJsonObject.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 
 @JsonTypeInfo(property = "type", use = Id.NAME)
@@ -21,11 +20,18 @@ import java.util.List;
 public abstract class GeoJsonObject implements Serializable
 {
 	private Crs crs;
-	private double[] bbox;
+
+	/**
+	 * A bounding box around the object, as currently configured.
+	 * This is initialized as {@code null} and dynamically updated each time the
+	 * object's geometry changes.
+	 */
+	private double[] bbox = null ;
 
 	/**
 	 * Starting bounds to guarantee that the various {@code calculateBounds}
 	 * methods will work out correctly.
+	 * @since issue #45
 	 */
 	protected static final double[] STARTING_BOUNDS =
 		{
@@ -37,6 +43,7 @@ public abstract class GeoJsonObject implements Serializable
 	 * Calculates the bounding box around a list of points.
 	 * @param points a list of points that compose a polygon
 	 * @return a bounding box
+	 * @since issue #45
 	 */
 	public static double[] calculateBounds( List<LngLatAlt> points )
 	{
@@ -63,10 +70,12 @@ public abstract class GeoJsonObject implements Serializable
 	 * @param currentBox the current bounding box
 	 * @param newData a new data point
 	 * @return the updated bounding box
+	 * @since issue #45
 	 */
 	@SuppressWarnings("UnusedReturnValue")
 	public static double[] accumulateBounds( double[] currentBox, double[] newData )
 	{
+		if( newData == null ) return currentBox ; // nothing to add
 		if( currentBox == null ) currentBox = STARTING_BOUNDS.clone() ;
 		if( Double.compare( newData[0], currentBox[0] ) < 0 )
 			currentBox[0] = newData[0] ;
@@ -88,20 +97,22 @@ public abstract class GeoJsonObject implements Serializable
 	}
 
 	@JsonIgnore
-	public double[] getBbox() {
-		return bbox;
-	}
+	public double[] getBbox()
+	{ return bbox ; }
 
+	/**
+	 * Sets an explicit bounding box.
+	 * @param bbox the explicit bounding box
+	 */
 	@JsonIgnore
-	public void setBbox(double[] bbox) {
-		this.bbox = bbox;
-	}
+	protected void setBbox( double[] bbox )
+	{ this.bbox = bbox ; }
 
 	/**
 	 * Calculates a bounding box around the object, and writes its coordinates
 	 * back to the internal bounding box.
 	 * @return the new bounding box (as from {@link #getBbox}.
-	 * @since issue #45 (zerobandwidth-net issue #1)
+	 * @since issue #45
 	 */
 	public abstract double[] calculateBounds() ;
 

--- a/src/main/java/org/geojson/Geometry.java
+++ b/src/main/java/org/geojson/Geometry.java
@@ -1,36 +1,50 @@
 package org.geojson;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 public abstract class Geometry<T> extends GeoJsonObject {
 
 	protected List<T> coordinates = new ArrayList<T>();
 
-	public Geometry() {
-	}
+	public Geometry() {	}
+
+	public Geometry( List<T> coords )
+	{ this.setCoordinates(coords) ; }
 
 	public Geometry( T... elements )
-	{
-		for( T coordinate : elements )
-			coordinates.add(coordinate) ;
-		this.calculateBounds() ;
-	}
+	{ this.setCoordinates( Arrays.asList(elements) ) ; }
 
+	/**
+	 * Adds some set of coordinates to the geometry.
+	 * Implies recalculation of the feature's bounding box.
+	 * @param elements the elements to be added
+	 * @return (fluid)
+	 */
 	public Geometry<T> add( T elements )
 	{
+		if( elements == null ) return this ; // trivially
 		coordinates.add(elements) ;
-		this.calculateBounds() ;
+		if( GeoJsonObject.class.isAssignableFrom( elements.getClass() ) )
+		{ // Recalculate more cheaply by simply adding this element.
+			this.setBbox( accumulateBounds( this.getBbox(),
+					((GeoJsonObject)(elements)).getBbox() )) ;
+		}
+		else this.calculateBounds() ;
 		return this;
 	}
 
-	public List<T> getCoordinates() {
-		return coordinates;
-	}
+	public List<T> getCoordinates()
+	{ return coordinates ; }
 
+	/**
+	 * Sets the list of coordinates that make up the geometry.
+ 	 * Implies a recalculation of the bounding box around the geometry.
+	 * @param coordinates the new list of coordinates
+	 */
 	public void setCoordinates( List<T> coordinates )
 	{
-		this.coordinates = coordinates ;
+		if( coordinates == null ) this.coordinates.clear() ;
+		else this.coordinates = coordinates ;
 		this.calculateBounds() ;
 	}
 

--- a/src/main/java/org/geojson/Geometry.java
+++ b/src/main/java/org/geojson/Geometry.java
@@ -10,14 +10,17 @@ public abstract class Geometry<T> extends GeoJsonObject {
 	public Geometry() {
 	}
 
-	public Geometry(T... elements) {
-		for (T coordinate : elements) {
-			coordinates.add(coordinate);
-		}
+	public Geometry( T... elements )
+	{
+		for( T coordinate : elements )
+			coordinates.add(coordinate) ;
+		this.calculateBounds() ;
 	}
 
-	public Geometry<T> add(T elements) {
-		coordinates.add(elements);
+	public Geometry<T> add( T elements )
+	{
+		coordinates.add(elements) ;
+		this.calculateBounds() ;
 		return this;
 	}
 
@@ -25,8 +28,10 @@ public abstract class Geometry<T> extends GeoJsonObject {
 		return coordinates;
 	}
 
-	public void setCoordinates(List<T> coordinates) {
-		this.coordinates = coordinates;
+	public void setCoordinates( List<T> coordinates )
+	{
+		this.coordinates = coordinates ;
+		this.calculateBounds() ;
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/src/main/java/org/geojson/GeometryCollection.java
+++ b/src/main/java/org/geojson/GeometryCollection.java
@@ -16,12 +16,9 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 	@Override
 	public double[] calculateBounds()
 	{
-		double[] box = { 0.0d, 0.0d, 0.0d, 0.0d } ;
+		double[] box = STARTING_BOUNDS.clone() ;
 		for( GeoJsonObject geo : this.getGeometries() )
-		{
-			double[] geobox = geo.calculateBounds() ;
-			GeoJsonObject.accumulateBounds( box, geobox ) ;
-		}
+			GeoJsonObject.accumulateBounds( box, geo.calculateBounds() ) ;
 		this.setBbox(box) ;
 		return this.getBbox() ;
 	}
@@ -30,8 +27,10 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 		return geometries;
 	}
 
-	public void setGeometries(List<GeoJsonObject> geometries) {
-		this.geometries = geometries;
+	public void setGeometries( List<GeoJsonObject> geometries )
+	{
+		this.geometries = geometries ;
+		this.calculateBounds() ;
 	}
 
 	@Override
@@ -39,9 +38,12 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 		return geometries.iterator();
 	}
 
-	public GeometryCollection add(GeoJsonObject geometry) {
-		geometries.add(geometry);
-		return this;
+	public GeometryCollection add( GeoJsonObject geometry )
+	{
+		geometries.add(geometry) ;
+		this.setBbox( accumulateBounds(
+				this.getBbox(), geometry.calculateBounds() ) ) ;
+		return this ;
 	}
 
 	@Override

--- a/src/main/java/org/geojson/GeometryCollection.java
+++ b/src/main/java/org/geojson/GeometryCollection.java
@@ -8,6 +8,24 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 
 	private List<GeoJsonObject> geometries = new ArrayList<GeoJsonObject>();
 
+	/**
+	 * {@inheritDoc}
+	 * Note that this method will cause all subsidiary objects to update their
+	 * bounding boxes as well.
+	 */
+	@Override
+	public double[] calculateBounds()
+	{
+		double[] box = { 0.0d, 0.0d, 0.0d, 0.0d } ;
+		for( GeoJsonObject geo : this.getGeometries() )
+		{
+			double[] geobox = geo.calculateBounds() ;
+			GeoJsonObject.accumulateBounds( box, geobox ) ;
+		}
+		this.setBbox(box) ;
+		return this.getBbox() ;
+	}
+
 	public List<GeoJsonObject> getGeometries() {
 		return geometries;
 	}

--- a/src/main/java/org/geojson/GeometryCollection.java
+++ b/src/main/java/org/geojson/GeometryCollection.java
@@ -8,20 +8,15 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 
 	private List<GeoJsonObject> geometries = new ArrayList<GeoJsonObject>();
 
+	public GeometryCollection() {}
+
 	/**
-	 * {@inheritDoc}
-	 * Note that this method will cause all subsidiary objects to update their
-	 * bounding boxes as well.
+	 * Constructs the collection with an initial list of geometries.
+	 * @param geos the initial list of geometries to be added
+	 * @since issue #45
 	 */
-	@Override
-	public double[] calculateBounds()
-	{
-		double[] box = STARTING_BOUNDS.clone() ;
-		for( GeoJsonObject geo : this.getGeometries() )
-			GeoJsonObject.accumulateBounds( box, geo.calculateBounds() ) ;
-		this.setBbox(box) ;
-		return this.getBbox() ;
-	}
+	public GeometryCollection( List<GeoJsonObject> geos )
+	{ this.setGeometries(geos) ; }
 
 	public List<GeoJsonObject> getGeometries() {
 		return geometries;
@@ -29,7 +24,8 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 
 	public void setGeometries( List<GeoJsonObject> geometries )
 	{
-		this.geometries = geometries ;
+		if( geometries == null ) this.geometries.clear() ;
+		else this.geometries = geometries ;
 		this.calculateBounds() ;
 	}
 
@@ -40,10 +36,26 @@ public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJso
 
 	public GeometryCollection add( GeoJsonObject geometry )
 	{
+		if( geometry == null ) return this ; // trivially
 		geometries.add(geometry) ;
 		this.setBbox( accumulateBounds(
 				this.getBbox(), geometry.calculateBounds() ) ) ;
 		return this ;
+	}
+
+	@Override
+	public double[] calculateBounds()
+	{
+		if( geometries.isEmpty() )
+			this.setBbox(null) ;
+		else
+		{
+			double[] box = STARTING_BOUNDS.clone() ;
+			for( GeoJsonObject geo : this.getGeometries() )
+				GeoJsonObject.accumulateBounds( box, geo.getBbox() ) ;
+			this.setBbox(box) ;
+		}
+		return this.getBbox() ;
 	}
 
 	@Override

--- a/src/main/java/org/geojson/LngLatAlt.java
+++ b/src/main/java/org/geojson/LngLatAlt.java
@@ -86,7 +86,8 @@ public class LngLatAlt implements Serializable{
 		return additionalElements;
 	}
 
-	public void setAdditionalElements(double... additionalElements) {
+	public void setAdditionalElements( double... additionalElements )
+	{
 		if (additionalElements != null) {
 			this.additionalElements = additionalElements;
 		} else {
@@ -135,25 +136,26 @@ public class LngLatAlt implements Serializable{
 	}
 
 	@Override
-	public String toString() {
-		String s =  "LngLatAlt{" + "longitude=" + longitude + ", latitude=" + latitude + ", altitude=" + altitude;
-
-		if (hasAdditionalElements()) {
-			s += ", additionalElements=[";
-
-			String suffix = "";
-			for (Double element : additionalElements) {
-				if (element != null) {
-					s += suffix + element;
-					suffix = ", ";
-				}
+	public String toString()
+	{ // (#45) Switched to using StringBuilder to avoid concatenation in loop.
+		StringBuilder sb = new StringBuilder() ;
+		sb.append( "LngLatAlt{longitude=" ).append( longitude )
+			.append( ", latitude=" ).append( latitude )
+			.append( ", altitude=" ).append( altitude )
+			;
+		if( this.hasAdditionalElements() )
+		{
+			sb.append( ", additionalElements=[" ) ;
+			String sPrefix = "" ;
+			for( Double element : this.additionalElements )
+			{
+				sb.append( sPrefix ).append( element ) ;
+				sPrefix = ", " ;
 			}
-			s += ']';
+			sb.append( "]" ) ;
 		}
-
-		s += '}';
-
-		return s;
+		sb.append( "}" ) ;
+		return sb.toString() ;
 	}
 
 	private void checkAltitudeAndAdditionalElements() {

--- a/src/main/java/org/geojson/MultiLineString.java
+++ b/src/main/java/org/geojson/MultiLineString.java
@@ -7,17 +7,21 @@ public class MultiLineString extends Geometry<List<LngLatAlt>> {
 	public MultiLineString() {
 	}
 
-	public MultiLineString(List<LngLatAlt> line) {
-		add(line);
-	}
+	public MultiLineString( List<LngLatAlt> line )
+	{ this.add(line) ; }
 
 	@Override
 	public double[] calculateBounds()
 	{
-		double[] box = STARTING_BOUNDS.clone() ;
-		for( List<LngLatAlt> shape : this.getCoordinates() )
-			accumulateBounds( box, calculateBounds(shape) ) ;
-		this.setBbox(box) ;
+		if( this.getCoordinates().isEmpty() )
+			this.setBbox(null) ;
+		else
+		{
+			double[] box = STARTING_BOUNDS.clone() ;
+			for( List<LngLatAlt> shape : this.getCoordinates() )
+				accumulateBounds( box, calculateBounds(shape) ) ;
+			this.setBbox(box) ;
+		}
 		return this.getBbox() ;
 	}
 

--- a/src/main/java/org/geojson/MultiLineString.java
+++ b/src/main/java/org/geojson/MultiLineString.java
@@ -12,6 +12,10 @@ public class MultiLineString extends Geometry<List<LngLatAlt>> {
 	}
 
 	@Override
+	public double[] calculateBounds()
+	{ return null ; }
+
+	@Override
 	public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
 		return geoJsonObjectVisitor.visit(this);
 	}

--- a/src/main/java/org/geojson/MultiLineString.java
+++ b/src/main/java/org/geojson/MultiLineString.java
@@ -13,7 +13,13 @@ public class MultiLineString extends Geometry<List<LngLatAlt>> {
 
 	@Override
 	public double[] calculateBounds()
-	{ return null ; }
+	{
+		double[] box = STARTING_BOUNDS.clone() ;
+		for( List<LngLatAlt> shape : this.getCoordinates() )
+			accumulateBounds( box, calculateBounds(shape) ) ;
+		this.setBbox(box) ;
+		return this.getBbox() ;
+	}
 
 	@Override
 	public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {

--- a/src/main/java/org/geojson/MultiPoint.java
+++ b/src/main/java/org/geojson/MultiPoint.java
@@ -12,7 +12,7 @@ public class MultiPoint extends Geometry<LngLatAlt> {
 	@Override
 	public double[] calculateBounds()
 	{
-		this.setBbox( GeoJsonObject.calculateBounds( this.getCoordinates() )) ;
+		this.setBbox( calculateBounds( this.getCoordinates() )) ;
 		return this.getBbox() ;
 	}
 

--- a/src/main/java/org/geojson/MultiPoint.java
+++ b/src/main/java/org/geojson/MultiPoint.java
@@ -10,6 +10,13 @@ public class MultiPoint extends Geometry<LngLatAlt> {
 	}
 
 	@Override
+	public double[] calculateBounds()
+	{
+		this.setBbox( GeoJsonObject.calculateBounds( this.getCoordinates() )) ;
+		return this.getBbox() ;
+	}
+
+	@Override
 	public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
 		return geoJsonObjectVisitor.visit(this);
 	}

--- a/src/main/java/org/geojson/MultiPolygon.java
+++ b/src/main/java/org/geojson/MultiPolygon.java
@@ -13,22 +13,27 @@ public class MultiPolygon extends Geometry<List<List<LngLatAlt>>> {
 
 	public MultiPolygon add(Polygon polygon)
 	{
+		if( polygon == null ) return this ; // trivially
 		coordinates.add(polygon.getCoordinates());
-		this.setBbox( accumulateBounds(
-				this.getBbox(), polygon.calculateBounds() )) ;
+		this.setBbox( accumulateBounds( this.getBbox(), polygon.getBbox() )) ;
 		return this;
 	}
 
 	@Override
 	public double[] calculateBounds()
 	{
-		double[] box = STARTING_BOUNDS.clone() ;
-		for( List<List<LngLatAlt>> polygroup : this.getCoordinates() )
+		if( this.coordinates.isEmpty() )
+			this.setBbox(null) ;
+		else
 		{
-			for( List<LngLatAlt> poly : polygroup )
-				accumulateBounds( box, calculateBounds(poly) ) ;
+			double[] box = STARTING_BOUNDS.clone() ;
+			for( List<List<LngLatAlt>> polygroup : this.getCoordinates() )
+			{
+				for( List<LngLatAlt> poly : polygroup )
+					accumulateBounds( box, calculateBounds(poly) ) ;
+			}
+			this.setBbox(box) ;
 		}
-		this.setBbox(box) ;
 		return this.getBbox() ;
 	}
 

--- a/src/main/java/org/geojson/MultiPolygon.java
+++ b/src/main/java/org/geojson/MultiPolygon.java
@@ -17,6 +17,22 @@ public class MultiPolygon extends Geometry<List<List<LngLatAlt>>> {
 	}
 
 	@Override
+	public double[] calculateBounds()
+	{
+		double[] box = { 0.0d, 0.0d, 0.0d, 0.0d } ;
+		for( List<List<LngLatAlt>> polygroup : this.getCoordinates() )
+		{
+			for( List<LngLatAlt> poly : polygroup )
+			{
+				double[] polybox = GeoJsonObject.calculateBounds( poly ) ;
+				GeoJsonObject.accumulateBounds( box, polybox ) ;
+			}
+		}
+		this.setBbox(box) ;
+		return this.getBbox() ;
+	}
+
+	@Override
 	public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
 		return geoJsonObjectVisitor.visit(this);
 	}

--- a/src/main/java/org/geojson/MultiPolygon.java
+++ b/src/main/java/org/geojson/MultiPolygon.java
@@ -11,22 +11,22 @@ public class MultiPolygon extends Geometry<List<List<LngLatAlt>>> {
 		add(polygon);
 	}
 
-	public MultiPolygon add(Polygon polygon) {
+	public MultiPolygon add(Polygon polygon)
+	{
 		coordinates.add(polygon.getCoordinates());
+		this.setBbox( accumulateBounds(
+				this.getBbox(), polygon.calculateBounds() )) ;
 		return this;
 	}
 
 	@Override
 	public double[] calculateBounds()
 	{
-		double[] box = { 0.0d, 0.0d, 0.0d, 0.0d } ;
+		double[] box = STARTING_BOUNDS.clone() ;
 		for( List<List<LngLatAlt>> polygroup : this.getCoordinates() )
 		{
 			for( List<LngLatAlt> poly : polygroup )
-			{
-				double[] polybox = GeoJsonObject.calculateBounds( poly ) ;
-				GeoJsonObject.accumulateBounds( box, polybox ) ;
-			}
+				accumulateBounds( box, calculateBounds(poly) ) ;
 		}
 		this.setBbox(box) ;
 		return this.getBbox() ;

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -4,8 +4,7 @@ public class Point extends GeoJsonObject {
 
 	private LngLatAlt coordinates;
 
-	public Point() {
-	}
+	public Point() {}
 
 	public Point(LngLatAlt coordinates) {
 		this.coordinates = coordinates;
@@ -21,6 +20,19 @@ public class Point extends GeoJsonObject {
 
 	public Point(double longitude, double latitude, double altitude, double... additionalElements) {
 		coordinates = new LngLatAlt(longitude, latitude, altitude, additionalElements);
+	}
+
+	@Override
+	public double[] calculateBounds()
+	{
+		this.setBbox( new double[]
+			{
+				coordinates.getLongitude(),
+				coordinates.getLatitude(),
+				coordinates.getLongitude(),
+				coordinates.getLatitude()
+			});
+		return this.getBbox() ;
 	}
 
 	public LngLatAlt getCoordinates() {

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -2,13 +2,12 @@ package org.geojson;
 
 public class Point extends GeoJsonObject {
 
-	private LngLatAlt coordinates;
+	private LngLatAlt coordinates = null ;
 
 	public Point() {}
 
-	public Point(LngLatAlt coordinates) {
-		this.coordinates = coordinates;
-	}
+	public Point(LngLatAlt coordinates)
+	{ this.setCoordinates(coordinates) ; }
 
 	public Point(double longitude, double latitude)
 	{ this.setCoordinates( new LngLatAlt(longitude, latitude) ) ; }
@@ -25,13 +24,18 @@ public class Point extends GeoJsonObject {
 	@Override
 	public double[] calculateBounds()
 	{
-		this.setBbox( new double[]
+		if( this.coordinates == null )
+			this.setBbox(null) ;
+		else
+		{
+			this.setBbox( new double[]
 			{
 				coordinates.getLongitude(),
 				coordinates.getLatitude(),
 				coordinates.getLongitude(),
 				coordinates.getLatitude()
 			});
+		}
 		return this.getBbox() ;
 	}
 
@@ -39,7 +43,7 @@ public class Point extends GeoJsonObject {
 		return coordinates;
 	}
 
-	public void setCoordinates(LngLatAlt coordinates)
+	public void setCoordinates( LngLatAlt coordinates )
 	{
 		this.coordinates = coordinates ;
 		this.calculateBounds() ;

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -10,16 +10,16 @@ public class Point extends GeoJsonObject {
 		this.coordinates = coordinates;
 	}
 
-	public Point(double longitude, double latitude) {
-		coordinates = new LngLatAlt(longitude, latitude);
-	}
+	public Point(double longitude, double latitude)
+	{ this.setCoordinates( new LngLatAlt(longitude, latitude) ) ; }
 
-	public Point(double longitude, double latitude, double altitude) {
-		coordinates = new LngLatAlt(longitude, latitude, altitude);
-	}
+	public Point(double longitude, double latitude, double altitude)
+	{ this.setCoordinates( new LngLatAlt(longitude, latitude, altitude) ) ; }
 
-	public Point(double longitude, double latitude, double altitude, double... additionalElements) {
-		coordinates = new LngLatAlt(longitude, latitude, altitude, additionalElements);
+	public Point(double longitude, double latitude, double altitude, double... additionalElements)
+	{
+		this.setCoordinates(
+			new LngLatAlt( longitude, latitude, altitude, additionalElements ));
 	}
 
 	@Override
@@ -39,8 +39,10 @@ public class Point extends GeoJsonObject {
 		return coordinates;
 	}
 
-	public void setCoordinates(LngLatAlt coordinates) {
-		this.coordinates = coordinates;
+	public void setCoordinates(LngLatAlt coordinates)
+	{
+		this.coordinates = coordinates ;
+		this.calculateBounds() ;
 	}
 
 	@Override

--- a/src/main/java/org/geojson/Polygon.java
+++ b/src/main/java/org/geojson/Polygon.java
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class Polygon extends Geometry<List<LngLatAlt>>
 {
 
-	public Polygon() {
-	}
+	public Polygon() {}
 
 	public Polygon(List<LngLatAlt> polygon) {
 		add(polygon);
@@ -19,8 +18,10 @@ public class Polygon extends Geometry<List<LngLatAlt>>
 		add(Arrays.asList(polygon));
 	}
 
-	public void setExteriorRing(List<LngLatAlt> points) {
-		coordinates.add(0, points);
+	public void setExteriorRing(List<LngLatAlt> points)
+	{
+		coordinates.add(0, points) ;
+		this.calculateBounds() ;
 	}
 
 	@JsonIgnore

--- a/src/main/java/org/geojson/Polygon.java
+++ b/src/main/java/org/geojson/Polygon.java
@@ -10,18 +10,18 @@ public class Polygon extends Geometry<List<LngLatAlt>>
 
 	public Polygon() {}
 
-	public Polygon(List<LngLatAlt> polygon) {
-		add(polygon);
-	}
+	public Polygon(List<LngLatAlt> polygon)
+	{ this.add(polygon) ; }
 
-	public Polygon(LngLatAlt... polygon) {
-		add(Arrays.asList(polygon));
-	}
+	public Polygon(LngLatAlt... polygon)
+	{ this.add(Arrays.asList(polygon)) ; }
 
 	public void setExteriorRing(List<LngLatAlt> points)
 	{
-		coordinates.add(0, points) ;
-		this.calculateBounds() ;
+		if( points == null ) return ; // trivially
+		coordinates.add( 0, points ) ;
+		this.setBbox( accumulateBounds( this.getBbox(),
+				calculateBounds(points) )) ;
 	}
 
 	@JsonIgnore
@@ -46,16 +46,22 @@ public class Polygon extends Geometry<List<LngLatAlt>>
 		coordinates.add(points);
 	}
 
-	public void addInteriorRing(LngLatAlt... points) {
-		assertExteriorRing();
-		coordinates.add(Arrays.asList(points));
-	}
+	public void addInteriorRing(LngLatAlt... points)
+	{ this.addInteriorRing( Arrays.asList(points) ) ; }
 
-	private void assertExteriorRing() {
+	private void assertExteriorRing()
+	{
 		if (coordinates.isEmpty())
 			throw new RuntimeException("No exterior ring defined.");
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Note that the various methods that add interior rings <i>do not</i>
+	 * assert that those rings are indeed within the bounds of the current
+	 * exterior ring. Thus the bounding box of the exterior ring might or might
+	 * not enclose all of the rings that are considered "interior".
+	 */
 	@Override
 	public double[] calculateBounds()
 	{

--- a/src/main/java/org/geojson/Polygon.java
+++ b/src/main/java/org/geojson/Polygon.java
@@ -5,7 +5,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public class Polygon extends Geometry<List<LngLatAlt>> {
+public class Polygon extends Geometry<List<LngLatAlt>>
+{
 
 	public Polygon() {
 	}
@@ -51,7 +52,14 @@ public class Polygon extends Geometry<List<LngLatAlt>> {
 
 	private void assertExteriorRing() {
 		if (coordinates.isEmpty())
-			throw new RuntimeException("No exterior ring definied");
+			throw new RuntimeException("No exterior ring defined.");
+	}
+
+	@Override
+	public double[] calculateBounds()
+	{
+		this.setBbox( calculateBounds( this.getExteriorRing() ) ) ;
+		return this.getBbox() ;
 	}
 
 	@Override

--- a/src/test/java/org/geojson/FeatureCollectionTest.java
+++ b/src/test/java/org/geojson/FeatureCollectionTest.java
@@ -1,0 +1,67 @@
+package org.geojson;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.geojson.GeoJsonObjectTest.TOLERANCE;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Exercises {@link FeatureCollection}.
+ * @since issue #45
+ */
+@RunWith(JUnit4.class)
+public class FeatureCollectionTest
+{
+	/**
+	 * Exercises {@link FeatureCollection#calculateBounds()}, and also verifies
+	 * that the setter methods will update the bounds automatically.
+	 */
+	@Test
+	public void testCalculateBounds()
+	{
+		FeatureCollection fc = new FeatureCollection() ;
+		Feature f1 = new Feature() ;
+		Polygon p1 = new Polygon(
+				new LngLatAlt( -1.0d, -1.0d ),
+				new LngLatAlt( 0.0d, 2.0d ),
+				new LngLatAlt( 1.0d, -2.0d )
+			);
+		f1.setGeometry(p1) ;
+		Feature f2 = new Feature() ;
+		Polygon p2 = new Polygon(
+				new LngLatAlt( -2.0d, 0.0d ),
+				new LngLatAlt( 0.0d, 3.0d ),
+				new LngLatAlt( 0.5d, 0.5d )
+			);
+		f2.setGeometry(p2) ;
+		List<Feature> aFeatures = new ArrayList<Feature>() ;
+		aFeatures.add(f1) ;
+		aFeatures.add(f2) ;
+		fc.setFeatures( aFeatures ) ;
+		double[] arExpected = { -2.0d, -2.0d, 1.0d, 3.0d } ;
+		assertArrayEquals( arExpected, fc.getBbox(), TOLERANCE ) ;
+		assertArrayEquals( arExpected, fc.calculateBounds(), TOLERANCE );
+		Feature f3 = new Feature() ;
+		Polygon p3 = new Polygon(
+				new LngLatAlt( -0.5d, 3.5d ),
+				new LngLatAlt( 0.1d, -2.0d ),
+				new LngLatAlt( 4.0d, 2.0d )
+			);
+		f3.setGeometry(p3) ;
+		fc.add(f3) ;
+		double[] arExpected3 = { -2.0d, -2.0d, 4.0d, 3.5d } ;
+		assertArrayEquals( arExpected3, fc.getBbox(), TOLERANCE ) ;
+		fc.setFeatures(null) ;
+		assertNull( fc.getBbox() ) ;
+		aFeatures.clear() ;
+		aFeatures.add(f1) ; aFeatures.add(f2) ; aFeatures.add(f3) ;
+		fc.addAll(aFeatures) ;
+		assertArrayEquals( arExpected3, fc.getBbox(), TOLERANCE ) ;
+	}
+}

--- a/src/test/java/org/geojson/FeatureTest.java
+++ b/src/test/java/org/geojson/FeatureTest.java
@@ -3,8 +3,10 @@ package org.geojson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import java.util.HashMap;
+
+import static org.geojson.GeoJsonObjectTest.TOLERANCE;
+import static org.junit.Assert.*;
 
 public class FeatureTest {
 
@@ -12,7 +14,8 @@ public class FeatureTest {
 	private ObjectMapper mapper = new ObjectMapper();
 
 	@Test
-	public void itShouldHaveProperties() throws Exception {
+	public void itShouldHaveProperties()
+	{
 		assertNotNull(testObject.getProperties());
 	}
 
@@ -23,5 +26,48 @@ public class FeatureTest {
 		// The value of the properties member is an object (any JSON object or a JSON null value).
 		assertEquals("{\"type\":\"Feature\",\"properties\":{},\"geometry\":null}",
 				mapper.writeValueAsString(testObject));
+	}
+
+	/**
+	 * Exercises {@link Feature#calculateBounds()}.
+	 * @since issue #45
+	 */
+	@Test
+	public void testCalculateBounds()
+	{
+		Feature f = new Feature() ;
+		Polygon p = new Polygon(
+				new LngLatAlt( -5.0d, -10.0d ),
+				new LngLatAlt( -7.0d, -12.0d ),
+				new LngLatAlt( -6.0d, 20.0d ),
+				new LngLatAlt( 15.0d, 11.0d ),
+				new LngLatAlt( 0.0d, -1.0d )
+			);
+		f.setGeometry(p) ;
+		double[] arExpected = { -7.0d, -12.0d, 15.0d, 20.0d } ;
+		assertArrayEquals( arExpected, f.getBbox(), TOLERANCE ) ;
+		assertArrayEquals( arExpected, f.calculateBounds(), TOLERANCE ) ;
+	}
+
+	/**
+	 * Exercises accessors/mutators for the feature "properties".
+	 * @since issue #45
+	 */
+	@Test
+	public void testProperties()
+	{
+		Feature f = new Feature() ;
+		f.setProperty( "foo", "bar" ) ;
+		assertEquals( "bar", f.getProperty("foo") ) ;
+		HashMap<String,Object> mapAlt = new HashMap<String,Object>() ;
+		mapAlt.put( "flargle", "bargle" ) ;
+		mapAlt.put( "dargle", "blarg" ) ;
+		f.setProperties(mapAlt) ;
+		assertNull( f.getProperty("foo") ) ;
+		assertEquals( "bargle", f.getProperty("flargle") ) ;
+		assertEquals( "blarg", f.getProperty("dargle") ) ;
+		f.setProperties(null) ;
+		assertNotNull( f.getProperties() ) ;
+		assertTrue( f.getProperties().isEmpty() ) ;
 	}
 }

--- a/src/test/java/org/geojson/GeoJsonObjectTest.java
+++ b/src/test/java/org/geojson/GeoJsonObjectTest.java
@@ -1,0 +1,15 @@
+package org.geojson;
+
+/**
+ * Exercises concrete methods provided by {@link GeoJsonObject}, and also
+ * provides constants for other tests.
+ * @since issue #45 (zerobandwidth-net issue #1)
+ */
+public class GeoJsonObjectTest
+{
+	/**
+	 * Tolerance of {@code assertEquals} evaluations against double-precision
+	 * floating point numbers, such as those used in the bounding box.
+	 */
+	public static final double TOLERANCE = 0.0000001d ;
+}

--- a/src/test/java/org/geojson/GeoJsonObjectTest.java
+++ b/src/test/java/org/geojson/GeoJsonObjectTest.java
@@ -1,9 +1,9 @@
 package org.geojson;
 
 /**
- * Exercises concrete methods provided by {@link GeoJsonObject}, and also
- * provides constants for other tests.
- * @since issue #45 (zerobandwidth-net issue #1)
+ * Provides constants used in other test classes. Eventually, this could also
+ * exercise the concrete methods provided by {@link GeoJsonObject} itself.
+ * @since issue #45
  */
 public class GeoJsonObjectTest
 {

--- a/src/test/java/org/geojson/LineStringTest.java
+++ b/src/test/java/org/geojson/LineStringTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Exercises {@link LineString}.
- * @since issue #45 (zerobandwidth-net issue #1)
+ * @since issue #45
  */
 @RunWith(JUnit4.class)
 public class LineStringTest
@@ -26,6 +26,7 @@ public class LineStringTest
 				new LngLatAlt( 0.0d, -1.0d )
 			);
 		double[] arExpected = { -7.0d, -12.0d, 15.0d, 20.0d } ;
+		assertArrayEquals( arExpected, ls.getBbox(), TOLERANCE ) ;
 		assertArrayEquals( arExpected, ls.calculateBounds(), TOLERANCE ) ;
 	}
 }

--- a/src/test/java/org/geojson/LineStringTest.java
+++ b/src/test/java/org/geojson/LineStringTest.java
@@ -1,0 +1,31 @@
+package org.geojson;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.geojson.GeoJsonObjectTest.TOLERANCE;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Exercises {@link LineString}.
+ * @since issue #45 (zerobandwidth-net issue #1)
+ */
+@RunWith(JUnit4.class)
+public class LineStringTest
+{
+	/** Exercises {@link LineString#calculateBounds} */
+	@Test
+	public void testCalculateBounds()
+	{
+		LineString ls = new LineString(
+				new LngLatAlt( -5.0d, -10.0d ),
+				new LngLatAlt( -7.0d, -12.0d ),
+				new LngLatAlt( -6.0d, 20.0d ),
+				new LngLatAlt( 15.0d, 11.0d ),
+				new LngLatAlt( 0.0d, -1.0d )
+			);
+		double[] arExpected = { -7.0d, -12.0d, 15.0d, 20.0d } ;
+		assertArrayEquals( arExpected, ls.calculateBounds(), TOLERANCE ) ;
+	}
+}

--- a/src/test/java/org/geojson/MultiPointTest.java
+++ b/src/test/java/org/geojson/MultiPointTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Exercises {@link MultiPoint}.
- * @since issue #45 (zerobandwidth-net issue #1)
+ * @since issue #45
  */
 @RunWith(JUnit4.class)
 public class MultiPointTest
@@ -26,6 +26,7 @@ public class MultiPointTest
 				new LngLatAlt( 0.0d, -1.0d )
 			);
 		double[] arExpected = { -7.0d, -12.0d, 15.0d, 20.0d } ;
+		assertArrayEquals( arExpected, mp.getBbox(), TOLERANCE ) ;
 		assertArrayEquals( arExpected, mp.calculateBounds(), TOLERANCE ) ;
 	}
 }

--- a/src/test/java/org/geojson/MultiPointTest.java
+++ b/src/test/java/org/geojson/MultiPointTest.java
@@ -1,0 +1,31 @@
+package org.geojson;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.geojson.GeoJsonObjectTest.TOLERANCE;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Exercises {@link MultiPoint}.
+ * @since issue #45 (zerobandwidth-net issue #1)
+ */
+@RunWith(JUnit4.class)
+public class MultiPointTest
+{
+	/** Exercises {@link MultiPoint#calculateBounds}. */
+	@Test
+	public void testCalculateBounds()
+	{
+		MultiPoint mp = new MultiPoint(
+				new LngLatAlt( -5.0d, -10.0d ),
+				new LngLatAlt( -7.0d, -12.0d ),
+				new LngLatAlt( -6.0d, 20.0d ),
+				new LngLatAlt( 15.0d, 11.0d ),
+				new LngLatAlt( 0.0d, -1.0d )
+			);
+		double[] arExpected = { -7.0d, -12.0d, 15.0d, 20.0d } ;
+		assertArrayEquals( arExpected, mp.calculateBounds(), TOLERANCE ) ;
+	}
+}

--- a/src/test/java/org/geojson/MultiPolygonTest.java
+++ b/src/test/java/org/geojson/MultiPolygonTest.java
@@ -1,0 +1,33 @@
+package org.geojson;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.geojson.GeoJsonObjectTest.TOLERANCE;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Exercises {@link MultiPolygon}.
+ * @since issue #45 (zerobandwidth-net issue #1)
+ */
+@RunWith(JUnit4.class)
+public class MultiPolygonTest
+{
+	/** Exercises {@link MultiPolygon#calculateBounds} */
+	@Test
+	public void testCalculateBounds()
+	{
+		MultiPolygon mp = new MultiPolygon() ;
+		mp.add( new Polygon(
+				new LngLatAlt( -1.0d, -2.0d ), new LngLatAlt( -3.0d, 4.0d ),
+				new LngLatAlt( 5.0d, 6.0d ), new LngLatAlt( 7.0d, -8.0d )
+			));
+		mp.add( new Polygon(
+				new LngLatAlt( 0.0d, 0.0d ), new LngLatAlt( -4.0d, 8.0d ),
+				new LngLatAlt( 10.0d, 5.0d ), new LngLatAlt( 6.0d, -11.0d )
+			));
+		double[] arExpected = { -4.0d, -11.0d, 10.0d, 8.0d } ;
+		assertArrayEquals( arExpected, mp.calculateBounds(), TOLERANCE ) ;
+	}
+}

--- a/src/test/java/org/geojson/MultiPolygonTest.java
+++ b/src/test/java/org/geojson/MultiPolygonTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Exercises {@link MultiPolygon}.
- * @since issue #45 (zerobandwidth-net issue #1)
+ * @since issue #45
  */
 @RunWith(JUnit4.class)
 public class MultiPolygonTest
@@ -28,6 +28,7 @@ public class MultiPolygonTest
 				new LngLatAlt( 10.0d, 5.0d ), new LngLatAlt( 6.0d, -11.0d )
 			));
 		double[] arExpected = { -4.0d, -11.0d, 10.0d, 8.0d } ;
+		assertArrayEquals( arExpected, mp.getBbox(), TOLERANCE ) ;
 		assertArrayEquals( arExpected, mp.calculateBounds(), TOLERANCE ) ;
 	}
 }

--- a/src/test/java/org/geojson/PointTest.java
+++ b/src/test/java/org/geojson/PointTest.java
@@ -8,7 +8,7 @@ import static org.geojson.GeoJsonObjectTest.TOLERANCE ;
 
 /**
  * Exercises {@link Point}.
- * @since issue #45 (zerobandwidth-net issue #1)
+ * @since issue #45
  */
 @RunWith(JUnit4.class)
 public class PointTest
@@ -19,6 +19,7 @@ public class PointTest
 	{
 		Point p = new Point( 5.0d, 10.0d ) ;
 		double[] arExpected = { 5.0d, 10.0d, 5.0d, 10.0d } ;
+		assertArrayEquals( arExpected, p.getBbox(), TOLERANCE ) ;
 		assertArrayEquals( arExpected, p.calculateBounds(), TOLERANCE ) ;
 	}
 }

--- a/src/test/java/org/geojson/PointTest.java
+++ b/src/test/java/org/geojson/PointTest.java
@@ -1,0 +1,24 @@
+package org.geojson;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import static org.junit.Assert.assertArrayEquals ;
+import static org.geojson.GeoJsonObjectTest.TOLERANCE ;
+
+/**
+ * Exercises {@link Point}.
+ * @since issue #45 (zerobandwidth-net issue #1)
+ */
+@RunWith(JUnit4.class)
+public class PointTest
+{
+	/** Exercises {@link Point#calculateBounds}. */
+	@Test
+	public void testCalculateBounds()
+	{
+		Point p = new Point( 5.0d, 10.0d ) ;
+		double[] arExpected = { 5.0d, 10.0d, 5.0d, 10.0d } ;
+		assertArrayEquals( arExpected, p.calculateBounds(), TOLERANCE ) ;
+	}
+}

--- a/src/test/java/org/geojson/PolygonTest.java
+++ b/src/test/java/org/geojson/PolygonTest.java
@@ -3,18 +3,23 @@ package org.geojson;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.assertArrayEquals ;
 
 import static org.geojson.GeoJsonObjectTest.TOLERANCE ;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Exercises {@link Polygon}.
- * @since issue #45 (zerobandwidth-net issue #1)
+ * @since issue #45
  */
 @RunWith(JUnit4.class)
 public class PolygonTest
 {
-	/** Exercises {@link GeoJsonObject#calculateBounds}. */
+	/** Exercises {@link Polygon#calculateBounds}. */
 	@Test
 	public void testCalculateBounds()
 	{
@@ -26,6 +31,37 @@ public class PolygonTest
 				new LngLatAlt( 0.0d, -1.0d )
 			);
 		double[] arExpected = { -7.0d, -12.0d, 15.0d, 20.0d } ;
+		assertArrayEquals( arExpected, p.getBbox(), TOLERANCE ) ;
 		assertArrayEquals( arExpected, p.calculateBounds(), TOLERANCE ) ;
 	}
+
+	/** Exercises methods that deal with exterior/interior ring management. */
+	@Test
+	public void testRingManagement()
+	{
+		Polygon p = new Polygon( // tiny triangle
+				new LngLatAlt( -0.1d, -0.1d ),
+				new LngLatAlt( 0.0d, 0.1d ),
+				new LngLatAlt( 0.1d, -0.1d )
+			);
+		List<LngLatAlt> newExterior = new ArrayList<LngLatAlt>() ; // bigger
+		newExterior.add( new LngLatAlt( -1.0d, -1.0d ) ) ;
+		newExterior.add( new LngLatAlt( 0.0d, 1.0d ) ) ;
+		newExterior.add( new LngLatAlt( 1.0d, -1.0d ) ) ;
+		p.setExteriorRing( newExterior ) ;
+		assertEquals( 2, p.getCoordinates().size() ) ;
+		List<LngLatAlt> poly = p.coordinates.get(0) ; // directly get the member
+		assertEquals( newExterior, poly ) ;
+
+		p.addInteriorRing( // triangle in size between the other two
+				new LngLatAlt( -0.2d, -0.2d ),
+				new LngLatAlt( 0.0d, 0.2d ),
+				new LngLatAlt( 0.2d, -0.2d )
+			);
+		assertEquals( 3, p.getCoordinates().size() ) ;
+		poly = p.coordinates.get(0) ;
+		assertEquals( newExterior, poly ) ; // big triangle is still the exterior
+
+	}
+
 }

--- a/src/test/java/org/geojson/PolygonTest.java
+++ b/src/test/java/org/geojson/PolygonTest.java
@@ -1,0 +1,31 @@
+package org.geojson;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import static org.junit.Assert.assertArrayEquals ;
+
+import static org.geojson.GeoJsonObjectTest.TOLERANCE ;
+
+/**
+ * Exercises {@link Polygon}.
+ * @since issue #45 (zerobandwidth-net issue #1)
+ */
+@RunWith(JUnit4.class)
+public class PolygonTest
+{
+	/** Exercises {@link GeoJsonObject#calculateBounds}. */
+	@Test
+	public void testCalculateBounds()
+	{
+		Polygon p = new Polygon(
+				new LngLatAlt( -5.0d, -10.0d ),
+				new LngLatAlt( -7.0d, -12.0d ),
+				new LngLatAlt( -6.0d, 20.0d ),
+				new LngLatAlt( 15.0d, 11.0d ),
+				new LngLatAlt( 0.0d, -1.0d )
+			);
+		double[] arExpected = { -7.0d, -12.0d, 15.0d, 20.0d } ;
+		assertArrayEquals( arExpected, p.calculateBounds(), TOLERANCE ) ;
+	}
+}

--- a/src/test/java/org/geojson/jackson/GeoJsonObjectTest.java
+++ b/src/test/java/org/geojson/jackson/GeoJsonObjectTest.java
@@ -12,6 +12,10 @@ public class GeoJsonObjectTest {
 	private class TestGeoJsonObject extends GeoJsonObject {
 
 		@Override
+		public double[] calculateBounds()
+		{ return this.getBbox() ; }
+
+		@Override
 		public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
 			throw new RuntimeException("not implemented");
 		}


### PR DESCRIPTION
This pull request includes changes to implement the proposal from issue #45 for real-time updates to each object's "bounding box". Along the way, it also adds a bit more unit test coverage to the existing classes.

### Approach ###

An abstract `calculateBounds()` method has been added to `GeoJsonObject` and implemented in each subclass. This method recalculates the bounding box around whatever coordinates are stored within the object. The method may be called explicitly, but it is also called by each method in each `GeoJsonObject` implementation which sets the object's geometry. This ensures that the value of the `bbox` class member is always up-to-date, even if the object's geometry changes over time. Since the base class's `equals()` method considered `bbox` in its requirements for equality, this was necessary to ensure that practically equal objects were programmatically considered equal.

For any geometric object that represents a single shape, the object recalculates its bounding box from scratch, each time it is modified. However, for any object that represents a list of shapes, or a list of points that define a shape, the object _accumulates_ bounding box statistics with each additional member. This is an attempt to improve the overall performance of the realtime update mechanism as much as possible.

### Consequences ###

There will likely be a slight performance hit because of the overhead of calculating this bounding box for each object. However every attempt has been made to minimize this in the algorithm used.

In order to prevent unintended rendering of the `bbox` member in JSON serializations, a `@JsonIgnore` annotation has been added to the accessor/mutator for this field in `GeoJsonObject`. (Without this annotation, once the bounding boxes were updated with non-null values, some previous unit tests began to fail.)

### Alternatives ###

As an alternative implementation, we could provide the `calculateBounds()` methods as a utility, but remove the consideration for the `bbox` member from all `equals()` methods. This would remove the need to keep `bbox` updated in realtime.

### Testing ###

A set of jUnit tests has been added to meaningfully each of the `calculateBounds()` methods. All existing unit tests also pass.

### Disclaimer ###

"Derpy" in the second commit comment is me admonishing myself for not checking my work the first time. :blush: :laughing: 