### PR TITLE
Bump jackson dependencies version to 2.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,17 +49,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.7.3</version>
+			<version>2.9.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.7.3</version>
+			<version>2.9.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.7.0</version>
+			<version>2.9.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION
Upgrade jackson libraries to latest version in order to fix dependency conflicts with recent deliveries of big java framework (such as dropwizard for example).