### PR TITLE
Issue 34 support foreign members

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/geojson/ArrayUtils.java
+++ b/src/main/java/org/geojson/ArrayUtils.java
@@ -1,0 +1,10 @@
+package org.geojson;
+
+final class ArrayUtils {
+  static String[] append(String[] array, String... components) {
+    String[] tempArray = new String[array.length + components.length];
+    System.arraycopy(array, 0, tempArray, 0, array.length);
+    System.arraycopy(components, 0, tempArray, array.length, components.length);
+    return tempArray;
+  }
+}

--- a/src/main/java/org/geojson/Feature.java
+++ b/src/main/java/org/geojson/Feature.java
@@ -1,81 +1,92 @@
 package org.geojson;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import static org.geojson.ArrayUtils.*;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Feature extends GeoJsonObject {
+  private static final String[] RESERVED_KEYS = append(GeoJsonObject.RESERVED_KEYS, "properties", "geometry", "id");
 
-	@JsonInclude(JsonInclude.Include.ALWAYS)
-	private Map<String, Object> properties = new HashMap<String, Object>();
-	@JsonInclude(JsonInclude.Include.ALWAYS)
-	private GeoJsonObject geometry;
-	private String id;
+  @Override
+  protected List<String> getReservedKeys() {
+    return Arrays.asList(RESERVED_KEYS);
+  }
 
-	public void setProperty(String key, Object value) {
-		properties.put(key, value);
-	}
+  @JsonInclude(JsonInclude.Include.ALWAYS)
+  private Map<String, Object> properties = new HashMap<String, Object>();
+  @JsonInclude(JsonInclude.Include.ALWAYS)
+  private GeoJsonObject geometry;
+  private String id;
 
-	@SuppressWarnings("unchecked")
-	public <T> T getProperty(String key) {
-		return (T)properties.get(key);
-	}
+  public void setProperty(String key, Object value) {
+    properties.put(key, value);
+  }
 
-	public Map<String, Object> getProperties() {
-		return properties;
-	}
+  @SuppressWarnings("unchecked")
+  public <T> T getProperty(String key) {
+    return (T) properties.get(key);
+  }
 
-	public void setProperties(Map<String, Object> properties) {
-		this.properties = properties;
-	}
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
 
-	public GeoJsonObject getGeometry() {
-		return geometry;
-	}
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
 
-	public void setGeometry(GeoJsonObject geometry) {
-		this.geometry = geometry;
-	}
+  public GeoJsonObject getGeometry() {
+    return geometry;
+  }
 
-	public String getId() {
-		return id;
-	}
+  public void setGeometry(GeoJsonObject geometry) {
+    this.geometry = geometry;
+  }
 
-	public void setId(String id) {
-		this.id = id;
-	}
+  public String getId() {
+    return id;
+  }
 
-	@Override
-	public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
-		return geoJsonObjectVisitor.visit(this);
-	}
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	@Override public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		if (!super.equals(o))
-			return false;
-		Feature feature = (Feature)o;
-		if (properties != null ? !properties.equals(feature.properties) : feature.properties != null)
-			return false;
-		if (geometry != null ? !geometry.equals(feature.geometry) : feature.geometry != null)
-			return false;
-		return !(id != null ? !id.equals(feature.id) : feature.id != null);
-	}
+  @Override
+  public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
+    return geoJsonObjectVisitor.visit(this);
+  }
 
-	@Override public int hashCode() {
-		int result = super.hashCode();
-		result = 31 * result + (properties != null ? properties.hashCode() : 0);
-		result = 31 * result + (geometry != null ? geometry.hashCode() : 0);
-		result = 31 * result + (id != null ? id.hashCode() : 0);
-		return result;
-	}
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    if (!super.equals(o))
+      return false;
+    Feature feature = (Feature) o;
+    if (properties != null ? !properties.equals(feature.properties) : feature.properties != null)
+      return false;
+    if (geometry != null ? !geometry.equals(feature.geometry) : feature.geometry != null)
+      return false;
+    return !(id != null ? !id.equals(feature.id) : feature.id != null);
+  }
 
-	@Override
-	public String toString() {
-		return "Feature{properties=" + properties + ", geometry=" + geometry + ", id='" + id + "'}";
-	}
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (properties != null ? properties.hashCode() : 0);
+    result = 31 * result + (geometry != null ? geometry.hashCode() : 0);
+    result = 31 * result + (id != null ? id.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Feature{properties=" + properties + ", geometry=" + geometry + ", id='" + id + "'}";
+  }
 }

--- a/src/main/java/org/geojson/FeatureCollection.java
+++ b/src/main/java/org/geojson/FeatureCollection.java
@@ -1,11 +1,20 @@
 package org.geojson;
 
+import static org.geojson.ArrayUtils.*;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
 public class FeatureCollection extends GeoJsonObject implements Iterable<Feature> {
+	private static final String[] RESERVED_KEYS = append(GeoJsonObject.RESERVED_KEYS, "features");
+
+	@Override
+	protected List<String> getReservedKeys() {
+		return Arrays.asList(RESERVED_KEYS);
+	}
 
 	private List<Feature> features = new ArrayList<Feature>();
 

--- a/src/main/java/org/geojson/GeoJsonObject.java
+++ b/src/main/java/org/geojson/GeoJsonObject.java
@@ -1,5 +1,6 @@
 package org.geojson;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -8,7 +9,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @JsonTypeInfo(property = "type", use = Id.NAME)
 @JsonSubTypes({ @Type(Feature.class), @Type(Polygon.class), @Type(MultiPolygon.class), @Type(FeatureCollection.class),
@@ -16,6 +21,24 @@ import java.util.Arrays;
                 @Type(GeometryCollection.class) })
 @JsonInclude(Include.NON_NULL)
 public abstract class GeoJsonObject implements Serializable {
+  static final String[] RESERVED_KEYS = new String[]{"crs", "bbox"};
+
+  private Map<String, Object> foreignMembers = new HashMap<String, Object>();
+
+  @JsonAnyGetter
+  public Map<String, Object> getForeignMembers() {
+    return foreignMembers;
+  }
+
+  public void addForeignMember(String key, Map<String, Object> value) {
+    if (getReservedKeys().contains(key.toLowerCase()))
+      throw new IllegalArgumentException("Invalid Foreign Member key " + key);
+    foreignMembers.put(key, value);
+  }
+
+  protected List<String> getReservedKeys() {
+    return Arrays.asList(RESERVED_KEYS);
+  }
 
 	private Crs crs;
 	private double[] bbox;

--- a/src/main/java/org/geojson/Geometry.java
+++ b/src/main/java/org/geojson/Geometry.java
@@ -1,9 +1,18 @@
 package org.geojson;
 
+import static org.geojson.ArrayUtils.*;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class Geometry<T> extends GeoJsonObject {
+	private static final String[] RESERVED_KEYS = append(GeoJsonObject.RESERVED_KEYS, "coordinates");
+
+	@Override
+	protected List<String> getReservedKeys() {
+		return Arrays.asList(RESERVED_KEYS);
+	}
 
 	protected List<T> coordinates = new ArrayList<T>();
 

--- a/src/main/java/org/geojson/GeometryCollection.java
+++ b/src/main/java/org/geojson/GeometryCollection.java
@@ -1,10 +1,19 @@
 package org.geojson;
 
+import static org.geojson.ArrayUtils.*;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
 public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJsonObject> {
+	private static final String[] RESERVED_KEYS = append(GeoJsonObject.RESERVED_KEYS, "geometries");
+
+	@Override
+	protected List<String> getReservedKeys() {
+		return Arrays.asList(RESERVED_KEYS);
+	}
 
 	private List<GeoJsonObject> geometries = new ArrayList<GeoJsonObject>();
 

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -1,6 +1,17 @@
 package org.geojson;
 
+import static org.geojson.ArrayUtils.*;
+
+import java.util.Arrays;
+import java.util.List;
+
 public class Point extends GeoJsonObject {
+	private static final String[] RESERVED_KEYS = append(GeoJsonObject.RESERVED_KEYS, "coordinates");
+
+	@Override
+	protected List<String> getReservedKeys() {
+		return Arrays.asList(RESERVED_KEYS);
+	}
 
 	private LngLatAlt coordinates;
 

--- a/src/test/java/org/geojson/ArrayUtilsTest.java
+++ b/src/test/java/org/geojson/ArrayUtilsTest.java
@@ -1,0 +1,15 @@
+package org.geojson;
+
+import static org.geojson.ArrayUtils.append;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class ArrayUtilsTest {
+  @Test
+  public void appends_elements_to_String_arrays() {
+    String[] array = new String[]{"a"};
+    assertThat(append(array, "b"), is(new String[]{"a", "b"}));
+  }
+}

--- a/src/test/java/org/geojson/ForeignMemberTest.java
+++ b/src/test/java/org/geojson/ForeignMemberTest.java
@@ -1,0 +1,59 @@
+package org.geojson;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ForeignMemberTest {
+  @Parameterized.Parameter(value = 0)
+  public String testName;
+
+  @Parameterized.Parameter(value = 1)
+  public GeoJsonObject gj;
+
+  @Parameterized.Parameter(value = 2)
+  public String reservedKey;
+
+  @Parameterized.Parameters(name = "{0} - {2}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"GeoJsonObject", abstractGeoJsonObjectFactory(), "crs"},
+        {"GeoJsonObject", abstractGeoJsonObjectFactory(), "bbox"},
+        {"GeoJsonObject", abstractGeoJsonObjectFactory(), "bbox"},
+        {"Feature", new Feature(), "properties"},
+        {"Feature", new Feature(), "geometry"},
+        {"Feature", new Feature(), "id"},
+        {"FeatureCollection", new FeatureCollection(), "features"},
+        {"Geometry", abstractGeometryFactory(), "coordinates"},
+        {"GeometryCollection", new GeometryCollection(), "geometries"},
+        {"Point", new Point(), "coordinates"},
+    });
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void prevents_setting_foreign_members_with_reserved_keys() {
+    gj.addForeignMember(reservedKey, Collections.<String, Object>emptyMap());
+  }
+
+  private static GeoJsonObject abstractGeoJsonObjectFactory() {
+    return new GeoJsonObject() {
+      @Override
+      public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
+        return null;
+      }
+    };
+  }
+
+  private static Geometry<Point> abstractGeometryFactory() {
+    return new Geometry<Point>() {
+      @Override
+      public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
+        return null;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Hi all!

I've been modifying this library to make it fit our needs back at https://github.com/opendatakit/briefcase/issues/661 and I thought that the changes I've made could be of interest.

We've basically added support for Foreign Members thanks to the `@JsonAnyGetter` Jackson annotation, which adds dynamic properties to the serialized JSON objects.

We've tested this on serialization so far and it probably needs some changes to work on deserialization. 

I wanted to create the PR in case it inspires someone to follow this. 

I think that deserialization could probably work with some well placed `@JsonCreator` annotations on constructors and I could probably work on this in the following weeks if this gets traction from this community.

I've tried to produce small, self-explaining commits. I hope it's easy to review.