### PR TITLE
fasterxml jakson dependency update CVE-2018-19361: FasterXML jackson-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,23 +42,24 @@
 
 	<properties>
 		<java-version>1.6</java-version>
+		<jackson-version>2.9.8</jackson-version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.9.6</version>
+			<version>${jackson-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.6</version>
+			<version>${jackson-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.9.6</version>
+			<version>${jackson-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION
…databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the openjpa class from polymorphic deserialization.