### PR TITLE
Replace exterior ring in setExteriorRing if it exists

### DIFF
--- a/src/main/java/org/geojson/Polygon.java
+++ b/src/main/java/org/geojson/Polygon.java
@@ -19,7 +19,11 @@ public class Polygon extends Geometry<List<LngLatAlt>> {
 	}
 
 	public void setExteriorRing(List<LngLatAlt> points) {
-		coordinates.add(0, points);
+		if (coordinates.isEmpty()) {
+			coordinates.add(0, points);
+		} else {
+			coordinates.set(0, points);
+		}
 	}
 
 	@JsonIgnore

--- a/src/test/java/org/geojson/jackson/PolygonTest.java
+++ b/src/test/java/org/geojson/jackson/PolygonTest.java
@@ -5,6 +5,8 @@ import org.geojson.LngLatAlt;
 import org.geojson.Polygon;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -44,6 +46,22 @@ public class PolygonTest {
 		assertListEquals(MockData.EXTERNAL, polygon.getExteriorRing());
 		assertListEquals(MockData.INTERNAL, polygon.getInteriorRing(0));
 		assertListEquals(MockData.INTERNAL, polygon.getInteriorRings().get(0));
+	}
+
+	@Test
+	public void itShouldSetExteriorRing() throws Exception {
+		Polygon polygon = new Polygon();
+		polygon.setExteriorRing(MockData.EXTERNAL);
+		assertEquals(MockData.EXTERNAL, polygon.getExteriorRing());
+	}
+
+	@Test
+	public void itShouldReplaceExteriorRing() throws Exception {
+		Polygon polygon = new Polygon(Arrays.asList(
+					new LngLatAlt(0, 0), new LngLatAlt(1, 0), new LngLatAlt(1, 1), new LngLatAlt(0, 1), new LngLatAlt(0, 0)));
+		polygon.setExteriorRing(MockData.EXTERNAL);
+		assertEquals(MockData.EXTERNAL, polygon.getExteriorRing());
+		assertEquals(0, polygon.getInteriorRings().size());
 	}
 
 	private void assertListEquals(List<LngLatAlt> expectedList, List<LngLatAlt> actualList) {


### PR DESCRIPTION
If a Polygon already has an exterior ring and setExteriorRing is called,
it would previously add the new ring to the start of the coordinates
list, so the existing exterior ring becomes an interior ring.