### PR TITLE
Point as a Geometry

### DIFF
--- a/src/main/java/org/geojson/Geometry.java
+++ b/src/main/java/org/geojson/Geometry.java
@@ -1,31 +1,21 @@
 package org.geojson;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public abstract class Geometry<T> extends GeoJsonObject {
 
-	protected List<T> coordinates = new ArrayList<T>();
+	protected T coordinates;
 
 	public Geometry() {
 	}
 
-	public Geometry(T... elements) {
-		for (T coordinate : elements) {
-			coordinates.add(coordinate);
-		}
+	public Geometry(T coordinates) {
+		this.coordinates = coordinates;
 	}
 
-	public Geometry<T> add(T elements) {
-		coordinates.add(elements);
-		return this;
-	}
-
-	public List<T> getCoordinates() {
+	public T getCoordinates() {
 		return coordinates;
 	}
 
-	public void setCoordinates(List<T> coordinates) {
+	public void setCoordinates(T coordinates) {
 		this.coordinates = coordinates;
 	}
 

--- a/src/main/java/org/geojson/LineString.java
+++ b/src/main/java/org/geojson/LineString.java
@@ -3,6 +3,7 @@ package org.geojson;
 public class LineString extends MultiPoint {
 
 	public LineString() {
+		super();
 	}
 
 	public LineString(LngLatAlt... points) {

--- a/src/main/java/org/geojson/MultiLineString.java
+++ b/src/main/java/org/geojson/MultiLineString.java
@@ -1,14 +1,22 @@
 package org.geojson;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class MultiLineString extends Geometry<List<LngLatAlt>> {
+public class MultiLineString extends Geometry<List<List<LngLatAlt>>> {
 
 	public MultiLineString() {
+		super(new ArrayList<List<LngLatAlt>>());
 	}
 
 	public MultiLineString(List<LngLatAlt> line) {
-		add(line);
+		super(new ArrayList<List<LngLatAlt>>(Collections.singletonList(line)));
+	}
+
+	public MultiLineString add(List<LngLatAlt> line) {
+		coordinates.add(line);
+		return this;
 	}
 
 	@Override

--- a/src/main/java/org/geojson/MultiPoint.java
+++ b/src/main/java/org/geojson/MultiPoint.java
@@ -1,15 +1,30 @@
 package org.geojson;
 
-public class MultiPoint extends Geometry<LngLatAlt> {
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class MultiPoint extends Geometry<List<LngLatAlt>> {
 
 	public MultiPoint() {
+		this(Collections.<LngLatAlt>emptyList());
 	}
 
 	public MultiPoint(LngLatAlt... points) {
-		super(points);
+		this(Arrays.asList(points));
 	}
 
-	@Override
+	private MultiPoint(List<LngLatAlt> points) {
+		super(new ArrayList<LngLatAlt>(points));
+	}
+
+	public MultiPoint add(LngLatAlt point) {
+		coordinates.add(point);
+		return this;
+	}
+
+		@Override
 	public <T> T accept(GeoJsonObjectVisitor<T> geoJsonObjectVisitor) {
 		return geoJsonObjectVisitor.visit(this);
 	}

--- a/src/main/java/org/geojson/MultiPolygon.java
+++ b/src/main/java/org/geojson/MultiPolygon.java
@@ -1,14 +1,21 @@
 package org.geojson;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class MultiPolygon extends Geometry<List<List<LngLatAlt>>> {
+public class MultiPolygon extends Geometry<List<List<List<LngLatAlt>>>> {
 
 	public MultiPolygon() {
+		this(Collections.<List<List<LngLatAlt>>>emptyList());
 	}
 
 	public MultiPolygon(Polygon polygon) {
-		add(polygon);
+		this(Collections.singletonList(polygon.getCoordinates()));
+	}
+
+	private MultiPolygon(List<List<List<LngLatAlt>>> elements) {
+		super(new ArrayList<List<List<LngLatAlt>>>(elements));
 	}
 
 	public MultiPolygon add(Polygon polygon) {

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -1,34 +1,25 @@
 package org.geojson;
 
-public class Point extends GeoJsonObject {
-
-	private LngLatAlt coordinates;
+public class Point extends Geometry<LngLatAlt> {
 
 	public Point() {
+		super();
 	}
 
-	public Point(LngLatAlt coordinates) {
-		this.coordinates = coordinates;
+	public Point(LngLatAlt coordinate) {
+		this.coordinates = coordinate;
 	}
 
 	public Point(double longitude, double latitude) {
-		coordinates = new LngLatAlt(longitude, latitude);
+		this(new LngLatAlt(longitude, latitude));
 	}
 
 	public Point(double longitude, double latitude, double altitude) {
-		coordinates = new LngLatAlt(longitude, latitude, altitude);
+		this(new LngLatAlt(longitude, latitude, altitude));
 	}
 
 	public Point(double longitude, double latitude, double altitude, double... additionalElements) {
-		coordinates = new LngLatAlt(longitude, latitude, altitude, additionalElements);
-	}
-
-	public LngLatAlt getCoordinates() {
-		return coordinates;
-	}
-
-	public void setCoordinates(LngLatAlt coordinates) {
-		this.coordinates = coordinates;
+		this(new LngLatAlt(longitude, latitude, altitude, additionalElements));
 	}
 
 	@Override
@@ -47,8 +38,9 @@ public class Point extends GeoJsonObject {
 		if (!super.equals(o)) {
 			return false;
 		}
-		Point point = (Point)o;
-		return !(coordinates != null ? !coordinates.equals(point.coordinates) : point.coordinates != null);
+		Point point = (Point) o;
+		return !(coordinates != null ? !coordinates.equals(point.coordinates)
+				: point.coordinates != null);
 	}
 
 	@Override
@@ -60,6 +52,6 @@ public class Point extends GeoJsonObject {
 
 	@Override
 	public String toString() {
-		return "Point{" + "coordinates=" + coordinates + "} " + super.toString();
+		return "Point{} " + super.toString();
 	}
 }

--- a/src/main/java/org/geojson/Polygon.java
+++ b/src/main/java/org/geojson/Polygon.java
@@ -1,21 +1,23 @@
 package org.geojson;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-public class Polygon extends Geometry<List<LngLatAlt>> {
+public class Polygon extends Geometry<List<List<LngLatAlt>>> {
 
 	public Polygon() {
+		super(new ArrayList<List<LngLatAlt>>());
 	}
 
 	public Polygon(List<LngLatAlt> polygon) {
-		add(polygon);
+		super(new ArrayList<List<LngLatAlt>>(Collections.singletonList(polygon)));
 	}
 
 	public Polygon(LngLatAlt... polygon) {
-		add(Arrays.asList(polygon));
+		this(Arrays.asList(polygon));
 	}
 
 	public void setExteriorRing(List<LngLatAlt> points) {
@@ -54,8 +56,9 @@ public class Polygon extends Geometry<List<LngLatAlt>> {
 	}
 
 	private void assertExteriorRing() {
-		if (coordinates.isEmpty())
+		if (coordinates.isEmpty()) {
 			throw new RuntimeException("No exterior ring definied");
+		}
 	}
 
 	@Override

--- a/src/test/java/org/geojson/ToStringTest.java
+++ b/src/test/java/org/geojson/ToStringTest.java
@@ -27,7 +27,7 @@ public class ToStringTest {
 	public void itShouldToStringPoint() throws Exception {
 		Point geometry = new Point(10, 20);
 		assertEquals(
-				"Point{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=NaN}} GeoJsonObject{}",
+				"Point{} Geometry{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=NaN}} GeoJsonObject{}",
 				geometry.toString());
 	}
 
@@ -35,7 +35,7 @@ public class ToStringTest {
 	public void itShouldToStringPointWithAdditionalElements() {
 		Point geometry = new Point(10, 20, 30, 40D, 50D);
 		assertEquals(
-				"Point{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=30.0, additionalElements=[40.0, 50.0]}} GeoJsonObject{}",
+				"Point{} Geometry{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=30.0, additionalElements=[40.0, 50.0]}} GeoJsonObject{}",
 				geometry.toString());
 	}
 
@@ -43,7 +43,7 @@ public class ToStringTest {
 	public void itShouldToStringPointWithAdditionalElementsAndIgnoreNulls() {
 		Point geometry = new Point(10, 20, 30, 40D, 50D);
 		assertEquals(
-				"Point{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=30.0, additionalElements=[40.0, 50.0]}} GeoJsonObject{}",
+				"Point{} Geometry{coordinates=LngLatAlt{longitude=10.0, latitude=20.0, altitude=30.0, additionalElements=[40.0, 50.0]}} GeoJsonObject{}",
 				geometry.toString());
 	}
 


### PR DESCRIPTION
According to GeoJson specifications (RFC 7946), a Point is a Geometry.

* Update Geometry object and all sub objects to accept a generic type T instead of a List<T> in order to accept Point as a Geometry
* Make Point a Geometry