### PR TITLE
Support for ObjectMapper AUTO_DETECT_GETTERS and AUTO_DETECT_SETTERS set to false

### DIFF
--- a/src/main/java/org/geojson/Crs.java
+++ b/src/main/java/org/geojson/Crs.java
@@ -2,10 +2,14 @@ package org.geojson;
 
 import org.geojson.jackson.CrsType;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public class Crs implements Serializable{
 
 	private CrsType type = CrsType.name;

--- a/src/main/java/org/geojson/Feature.java
+++ b/src/main/java/org/geojson/Feature.java
@@ -1,10 +1,13 @@
 package org.geojson;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public class Feature extends GeoJsonObject {
 
 	@JsonInclude(JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/geojson/FeatureCollection.java
+++ b/src/main/java/org/geojson/FeatureCollection.java
@@ -5,6 +5,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public class FeatureCollection extends GeoJsonObject implements Iterable<Feature> {
 
 	private List<Feature> features = new ArrayList<Feature>();

--- a/src/main/java/org/geojson/GeoJsonObject.java
+++ b/src/main/java/org/geojson/GeoJsonObject.java
@@ -3,6 +3,8 @@ package org.geojson;
 import java.io.Serializable;
 import java.util.Arrays;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -17,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
                 @Type(GeometryCollection.class) })
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public abstract class GeoJsonObject implements Serializable {
 
 	private Crs crs;

--- a/src/main/java/org/geojson/Geometry.java
+++ b/src/main/java/org/geojson/Geometry.java
@@ -3,6 +3,10 @@ package org.geojson;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public abstract class Geometry<T> extends GeoJsonObject {
 
 	protected List<T> coordinates = new ArrayList<T>();

--- a/src/main/java/org/geojson/GeometryCollection.java
+++ b/src/main/java/org/geojson/GeometryCollection.java
@@ -4,6 +4,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public class GeometryCollection extends GeoJsonObject implements Iterable<GeoJsonObject> {
 
 	private List<GeoJsonObject> geometries = new ArrayList<GeoJsonObject>();

--- a/src/main/java/org/geojson/Point.java
+++ b/src/main/java/org/geojson/Point.java
@@ -1,5 +1,9 @@
 package org.geojson;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public class Point extends GeoJsonObject {
 
 	private LngLatAlt coordinates;

--- a/src/main/java/org/geojson/Polygon.java
+++ b/src/main/java/org/geojson/Polygon.java
@@ -3,8 +3,11 @@ package org.geojson;
 import java.util.Arrays;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 
+@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
 public class Polygon extends Geometry<List<LngLatAlt>> {
 
 	public Polygon() {

--- a/src/test/java/org/geojson/NoAutoDetectGettersTest.java
+++ b/src/test/java/org/geojson/NoAutoDetectGettersTest.java
@@ -1,0 +1,43 @@
+package org.geojson;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+public class NoAutoDetectGettersTest {
+
+	private Feature testObject;
+	private ObjectMapper mapper;
+
+	@Before
+    public void setUp() {
+		mapper = new ObjectMapper();
+		mapper.configure(MapperFeature.AUTO_DETECT_GETTERS, false);
+		mapper.configure(MapperFeature.AUTO_DETECT_SETTERS, false);
+
+		testObject = new Feature();
+		testObject.setGeometry(new Polygon(new LngLatAlt(15, 58)));
+    }
+
+
+	@Test
+	public void itShouldSerializePropertiesAndGeometry() throws Exception {
+		// Make sure that the serialized object contains properties and 
+		// geometry (that are defined using getters/setters), even though
+		// auto detect getters & setters are disabled on the ObjectMapper.
+
+		assertEquals("{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[15.0,58.0]]]}}",
+				mapper.writeValueAsString(testObject));
+	}
+
+	@Test
+	public void itShouldParsePropertiesAndGeometry() throws Exception {
+		Feature feature = mapper.readValue("{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[15.0,58.0]]]}}", Feature.class);
+		assertEquals(testObject, feature);
+	}
+}


### PR DESCRIPTION
Fixes #43

We had the same issue as #43, we create our ObjectMapper with these settings:

```java
mapper = new ObjectMapper();
mapper.configure(MapperFeature.AUTO_DETECT_GETTERS, false);
mapper.configure(MapperFeature.AUTO_DETECT_SETTERS, false);
...
```

We can easily add support for this case to this library using the following annotation to all classes that are supposed to be (de)serialized using jackson and use getters/setters:
```java
@JsonAutoDetect(getterVisibility = Visibility.PUBLIC_ONLY, setterVisibility = Visibility.PUBLIC_ONLY)
```

This will not affect existing users that are using the default values of AUTO_DETECT_*, as `getterVisibility = Visibility.PUBLIC_ONLY` and `setterVisibility = Visibility.PUBLIC_ONLY` are the defaults.

