### PR TITLE
Prevent Jackson from unwrapping List in Geometry

### DIFF
--- a/src/main/java/org/geojson/Geometry.java
+++ b/src/main/java/org/geojson/Geometry.java
@@ -3,8 +3,11 @@ package org.geojson;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 public abstract class Geometry<T> extends GeoJsonObject {
 
+	@JsonFormat(without = JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED)
 	protected List<T> coordinates = new ArrayList<T>();
 
 	public Geometry() {

--- a/src/test/java/org/geojson/jackson/MultiLineStringTest.java
+++ b/src/test/java/org/geojson/jackson/MultiLineStringTest.java
@@ -1,6 +1,8 @@
 package org.geojson.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import org.geojson.LngLatAlt;
 import org.geojson.MultiLineString;
 import org.junit.Test;
@@ -20,5 +22,16 @@ public class MultiLineStringTest {
 		multiLineString.add(Arrays.asList(new LngLatAlt(102, 2), new LngLatAlt(103, 3)));
 		assertEquals("{\"type\":\"MultiLineString\",\"coordinates\":"
 				+ "[[[100.0,0.0],[101.0,1.0]],[[102.0,2.0],[103.0,3.0]]]}", mapper.writeValueAsString(multiLineString));
+	}
+
+	@Test
+	public void itShouldSerializeIgnoringWriteSingleElemArraysUnwrapped() throws Exception {
+		ObjectMapper mapper = new ObjectMapper()
+			.enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
+
+		MultiLineString multiLineString = new MultiLineString();
+		multiLineString.add(Arrays.asList(new LngLatAlt(100, 0), new LngLatAlt(101, 1)));
+		assertEquals("{\"type\":\"MultiLineString\",\"coordinates\":"
+				+ "[[[100.0,0.0],[101.0,1.0]]]}", mapper.writeValueAsString(multiLineString));
 	}
 }

--- a/src/test/java/org/geojson/jackson/MultiPoligonTest.java
+++ b/src/test/java/org/geojson/jackson/MultiPoligonTest.java
@@ -1,6 +1,8 @@
 package org.geojson.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import org.geojson.LngLatAlt;
 import org.geojson.MultiPolygon;
 import org.geojson.Polygon;
@@ -14,6 +16,24 @@ public class MultiPoligonTest {
 
 	@Test
 	public void itShouldSerialize() throws Exception {
+		MultiPolygon multiPolygon = new MultiPolygon();
+		multiPolygon.add(new Polygon(new LngLatAlt(102, 2), new LngLatAlt(103, 2), new LngLatAlt(103, 3),
+				new LngLatAlt(102, 3), new LngLatAlt(102, 2)));
+		Polygon polygon = new Polygon(MockData.EXTERNAL);
+		polygon.addInteriorRing(MockData.INTERNAL);
+		multiPolygon.add(polygon);
+		assertEquals(
+				"{\"type\":\"MultiPolygon\",\"coordinates\":[[[[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,3.0],[102.0,2.0]]],"
+						+ "[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],"
+						+ "[[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]]]]}",
+				mapper.writeValueAsString(multiPolygon));
+	}
+
+	@Test
+	public void itShouldSerializeIgnoringWriteSingleElemArraysUnwrapped() throws Exception {
+		ObjectMapper mapper = new ObjectMapper()
+			.enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
+
 		MultiPolygon multiPolygon = new MultiPolygon();
 		multiPolygon.add(new Polygon(new LngLatAlt(102, 2), new LngLatAlt(103, 2), new LngLatAlt(103, 3),
 				new LngLatAlt(102, 3), new LngLatAlt(102, 2)));

--- a/src/test/java/org/geojson/jackson/PolygonTest.java
+++ b/src/test/java/org/geojson/jackson/PolygonTest.java
@@ -1,12 +1,13 @@
 package org.geojson.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import org.geojson.LngLatAlt;
 import org.geojson.Polygon;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -21,6 +22,19 @@ public class PolygonTest {
 		assertEquals("{\"type\":\"Polygon\",\"coordinates\":"
 				+ "[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}",
 				mapper.writeValueAsString(polygon));
+	}
+
+	@Test
+	public void itShouldSerializeIgnoringWriteSingleElemArraysUnwrapped() throws Exception {
+		ObjectMapper mapper = new ObjectMapper()
+			.enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED)
+		;
+
+		Polygon polygon = new Polygon(MockData.EXTERNAL);
+		String actual = mapper.writeValueAsString(polygon);
+		assertEquals("{\"type\":\"Polygon\",\"coordinates\":"
+			+ "[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}",
+			actual);
 	}
 
 	@Test


### PR DESCRIPTION
When a `Geometry` containing a single list of `LngLatAlt` within its coordinates list was serialized using an [ObjectMapper](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/com/fasterxml/jackson/databind/ObjectMapper.html) with [SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/com/fasterxml/jackson/databind/SerializationFeature.html#WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED) enabled the resulting output no longer matched the examples in [RFC7946](https://datatracker.ietf.org/doc/html/rfc7946) due to the array brackets for the coordinates list being omitted. This deviation in expected json format prevents deserialization of the output back to the original `Geometry`. Preventing this feature from activating on the coordinates list in `Geometry`, even when enabled in the `ObjectMapper`, resolves the breaking of the idempotent nature of serialization and deserialization by keeping the output as close to the examples in RFC7946 as possible.